### PR TITLE
Fixing issue with string mappings

### DIFF
--- a/Sources/SolToBoogie/MapArrayHelper.cs
+++ b/Sources/SolToBoogie/MapArrayHelper.cs
@@ -8,7 +8,8 @@ namespace SolToBoogie
 
     public class MapArrayHelper
     {
-        private static Regex mappingRegex = new Regex(@"mapping\((\w+)\s*=>\s*(.+)\)$");
+        private static Regex mappingRegex = new Regex(@"mapping\((\w+)\s*\w*\s*=>\s*(.+)\)$");
+        //mapping(string => uint) appears as mapping(string memory => uint)
         private static Regex arrayRegex = new Regex(@"(.+)\[\w*\] (storage ref|storage pointer|memory)$");
         // mapping (uint => uint[]) does not have storage/memory in Typestring
         // private static Regex arrayRegex = new Regex(@"(.+)\[\w*\]$");
@@ -56,6 +57,14 @@ namespace SolToBoogie
             else if (typeString.StartsWith("contract "))
             {
                 return BoogieType.Ref;
+            }
+            else if (typeString.Equals("string") || typeString.StartsWith("string "))
+            {
+                return BoogieType.Int; //we think of string as its hash
+            }
+            else if (typeString.StartsWith("literal_string "))
+            {
+                return BoogieType.Int; //we think of string as its hash
             }
             else
             {

--- a/Test/config/StringMapping.json
+++ b/Test/config/StringMapping.json
@@ -1,0 +1,6 @@
+{
+    "recursionBound": 8,
+    "k": 1,
+    "main": "CorralEntry_Mapping",
+    "expectedResult": "Program has no bugs"
+}

--- a/Test/records.txt
+++ b/Test/records.txt
@@ -64,3 +64,5 @@ MappingNested.sol
 #Modifier.sol
 NoConstructor.sol
 ReturnNamedParam.sol
+StringMapping.sol
+#StringMappingNoConstructor.sol

--- a/Test/regressions/StringMapping.sol
+++ b/Test/regressions/StringMapping.sol
@@ -4,11 +4,15 @@ contract Mapping {
 
     mapping (string => uint) m;
 
-    constructor() public {
-        m["aa"] = 11;
-        m["bb"] = 21;
+    constructor(string s) public {        
+        m[s] = 21;    // string memory
+        assert (m[s] == 21);
+
+        m["aa"] = 11; // literal string
         assert (m["aa"] == 11);
-        assert (m["bb"] == 21);
+
+        string memory aaString = "aa";
+        assert (m[aaString] == 11);
     }
 
 }

--- a/Test/regressions/StringMapping.sol
+++ b/Test/regressions/StringMapping.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.24;
+
+contract Mapping {
+
+    mapping (string => uint) m;
+
+    constructor() public {
+        m["aa"] = 11;
+        m["bb"] = 21;
+        assert (m["aa"] == 11);
+        assert (m["bb"] == 21);
+    }
+
+}

--- a/Test/regressions/StringMappingNoConstructor.sol
+++ b/Test/regressions/StringMappingNoConstructor.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.24;
+
+contract Mapping {
+
+    mapping (string => uint) m;
+
+    function test() public {
+        m["aa"] = 11;
+        m["bb"] = 21;
+        assert (m["aa"] == 11);
+        assert (m["bb"] == 21);
+    }
+
+}

--- a/scripts/run_verisol_win.cmd
+++ b/scripts/run_verisol_win.cmd
@@ -29,10 +29,17 @@ del pretty.bpl
 
 set BINARYDEPENDENCIES=%VERISOL_ROOT_DIR%\verisol_dependencies\
 
+if NOT EXIST %BINARYDEPENDENCIES% (
+    echo "Could not find the verisol_dependencies folder"
+    goto :exit
+)
+
 @echo off
 REM Generate BPL 
 echo Compiling sol files and generating boogie files ....
+@echo on
 dotnet %VERISOL_ROOT_DIR%\Sources\SolToBoogie\bin\Debug\netcoreapp2.0\SolToBoogie.dll %1.sol %VERISOL_ROOT_DIR% out.bpl
+@echo off
 
 REM Check for syntax issues and pretty print
 echo Pretty printing boogie files....


### PR DESCRIPTION
Mappings with string used to crash due to "string memory" which the regex did not expect. Please review the change in the mappingRegex and related changes for string. 