### PR TITLE
initializing strings and integer state variables in constructor

### DIFF
--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -194,6 +194,30 @@ namespace SolToBoogie
                         BoogieAssignCmd assignCmd = new BoogieAssignCmd(lhs, new BoogieIdentifierExpr("null"));
                         stmtList.AddStatement(assignCmd);
                     }
+                    else if (elementaryType.TypeDescriptions.TypeString.Equals("bool"))
+                    {
+                        string varName = TransUtils.GetCanonicalStateVariableName(varDecl, context);
+                        BoogieExpr lhs = new BoogieMapSelect(new BoogieIdentifierExpr(varName), new BoogieIdentifierExpr("this"));
+                        BoogieAssignCmd assignCmd = new BoogieAssignCmd(lhs, new BoogieLiteralExpr(false));
+                        stmtList.AddStatement(assignCmd);
+                    }
+                    else if (elementaryType.TypeDescriptions.TypeString.Equals("string")) 
+                    {
+                        string x = "";
+                        int hashCode = x.GetHashCode();
+                        BigInteger num = new BigInteger(hashCode);
+                        string varName = TransUtils.GetCanonicalStateVariableName(varDecl, context);
+                        BoogieExpr lhs = new BoogieMapSelect(new BoogieIdentifierExpr(varName), new BoogieIdentifierExpr("this"));
+                        BoogieAssignCmd assignCmd = new BoogieAssignCmd(lhs, new BoogieLiteralExpr(num));
+                        stmtList.AddStatement(assignCmd);
+                    }
+                    else //it is integer valued
+                    {
+                        string varName = TransUtils.GetCanonicalStateVariableName(varDecl, context);
+                        BoogieExpr lhs = new BoogieMapSelect(new BoogieIdentifierExpr(varName), new BoogieIdentifierExpr("this"));
+                        BoogieAssignCmd assignCmd = new BoogieAssignCmd(lhs, new BoogieLiteralExpr(BigInteger.Zero));
+                        stmtList.AddStatement(assignCmd);
+                    }
                 }
             }
 

--- a/Test/regressions/StateVarInit.sol
+++ b/Test/regressions/StateVarInit.sol
@@ -1,0 +1,28 @@
+pragma solidity ^0.4.24;
+
+contract A {
+      uint x;
+      int128 x128;
+      string y;
+      address z;
+      bool w;
+
+      constructor() {
+          assert(x == 0);
+          assert(x128 == 0);
+          assert(z == 0x0);
+          assert(!w);
+
+          string memory yval = "";
+          bytes32 a = keccak256(bytes(y));
+          bytes32 b = keccak256(bytes(yval));
+          assert(a == b);
+
+          y = "aa";
+          a = keccak256(bytes(y));
+          assert(a != b);
+
+
+
+      }
+}


### PR DESCRIPTION
we were not initializing strings and integers, only address valued state vars. 