### PR TITLE
Shuvendu single regression

### DIFF
--- a/Sources/SolToBoogieTest/Program.cs
+++ b/Sources/SolToBoogieTest/Program.cs
@@ -10,14 +10,16 @@ namespace SolToBoogieTest
     {
         public static void Main(string[] args)
         {
-            if (args.Length != 2)
+            if (args.Length < 2 || args.Length > 3)
             {
-                Console.WriteLine("Usage: SolToBoogieTest <path-to-corral> <workingdir>");
+                Console.WriteLine("Usage: SolToBoogieTest <path-to-corral> <workingdir> [<test-prefix>]");
+                Console.WriteLine("\t: if <test-prefix> is specified, we only run subset of tests that have the string as prefix");
                 return;
             }
 
             string corralPath = args[0];
             string workingDirectory = args[1];
+            string testPrefix = args.Length >= 3 ? args[2] : ""; 
             string solcName = GetSolcNameByOSPlatform();
             string solcPath = Path.Combine(workingDirectory, "Tool", solcName);
             string testDir = Path.Combine(workingDirectory, "Test", "regressions");
@@ -27,7 +29,11 @@ namespace SolToBoogieTest
             ILoggerFactory loggerFactory = new LoggerFactory().AddConsole(LogLevel.Information);
             ILogger logger = loggerFactory.CreateLogger("SolToBoogieTest.RegressionExecutor");
 
-            RegressionExecutor executor = new RegressionExecutor(solcPath, corralPath, testDir, configDir, recordsDir, logger);
+            if (!testPrefix.Equals(string.Empty))
+            {
+                Console.WriteLine($"Warning!!! only running tests that have a prefix {testPrefix}....");
+            }
+            RegressionExecutor executor = new RegressionExecutor(solcPath, corralPath, testDir, configDir, recordsDir, logger, testPrefix);
             executor.BatchExecute();
         }
 

--- a/Sources/SolToBoogieTest/RegressionExecutor.cs
+++ b/Sources/SolToBoogieTest/RegressionExecutor.cs
@@ -26,13 +26,15 @@ namespace SolToBoogieTest
 
         private ILogger logger;
 
+        private string testPrefix;
+
         private static readonly int corralTimeoutInMilliseconds = TimeSpan.FromSeconds(60).Seconds * 1000;
 
         private static readonly string outFile = "__SolToBoogieTest_out.bpl";
 
         private static Dictionary<string, bool> filesToRun = new Dictionary<string, bool>();
 
-        public RegressionExecutor(string solcPath, string corralPath, string testDirectory, string configDirectory, string recordsDir, ILogger logger)
+        public RegressionExecutor(string solcPath, string corralPath, string testDirectory, string configDirectory, string recordsDir, ILogger logger, string testPrefix = "")
         {
             this.solcPath = solcPath;
             this.corralPath = corralPath;
@@ -40,6 +42,7 @@ namespace SolToBoogieTest
             this.configDirectory = configDirectory;
             this.recordsDir = recordsDir;
             this.logger = logger;
+            this.testPrefix = testPrefix;
         }
 
         public bool BatchExecute()
@@ -51,6 +54,8 @@ namespace SolToBoogieTest
             foreach (string filePath in filePaths)
             {
                 string filename = Path.GetFileName(filePath);
+                if (!filename.StartsWith(testPrefix))
+                    continue;
                 if (!filesToRun.ContainsKey(filename))
                 {
                     logger.LogWarning($"{filename} not found in {Path.Combine(recordsDir, "records.txt")}");

--- a/Test/config/Getters.json
+++ b/Test/config/Getters.json
@@ -1,0 +1,6 @@
+{
+    "recursionBound": 8,
+    "k": 1,
+    "main": "CorralEntry_B",
+    "expectedResult": "Program has no bugs"
+}

--- a/Test/regressions/Getters.sol
+++ b/Test/regressions/Getters.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.4.24;
+
+contract A {
+    uint public x;
+    constructor () {x = 11;}
+}
+
+contract B {
+    A a;
+    function Foo() public {
+        a = new A();
+        uint y = a.x();
+        assert(y == 11);
+    }
+}


### PR DESCRIPTION
Adding an optional argument to run only a single/subset of tests using the script. 

 Usage: SolToBoogieTest path-to-corral workingdir [test-prefix]
                if test-prefix is specified, we only run subset of tests that have the string as prefix
