### PR TITLE
Change the name of corral to lower cases

### DIFF
--- a/Sources/SolToBoogieTest/Program.cs
+++ b/Sources/SolToBoogieTest/Program.cs
@@ -60,7 +60,7 @@ namespace SolToBoogieTest
                         ).FullName
                         ).FullName
                         ).FullName;
-            return Path.Combine(new string[] {verisolRoot, "Corral", "bin", "debug", "Corral.exe"});
+            return Path.Combine(new string[] {verisolRoot, "corral", "bin", "debug", "corral.exe"});
         }
 
         private static string GetSolcNameByOSPlatform()


### PR DESCRIPTION
Switch to lower cases for the path to corral binary, because Linux is case sensitive for paths. Please check this would also work on Windows and Mac.