### PR TITLE
Ellab upgrade solc 5

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,7 +66,7 @@ To run the regressions, let %VERISOL_PATH% denote path to the root of the instal
 
 All regressions are expected to pass. 
 
-To run a subset of examples during testing, add an optional parameter to limit the above run to a subset of tests that match a prefix string *<prefix>*
+To run a subset of examples during testing, add an optional parameter to limit the above run to a subset of tests that match a prefix string *<prefix>* (e.g. using Array will only run regresssions with Array in their prefix)
 
 `dotnet %VERISOL_PATH%\Sources\SolToBoogieTest\bin\Debug\netcoreapp2.2\SolToBoogieTest.dll %VERISOL_PATH% %VERISOL_PATH%\test\ [<prefix>]`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@
 ## Dependencies
 
 - Install **.NET Core** (version **2.2**) for Windows/Linux/OSX from [here](https://dotnet.microsoft.com/download/dotnet-core/2.2#sdk-2.2.106) 
-- Install **Solidity compiler** (version **0.4.24**) binaries for Windows/Linux/OSX from [here](https://github.com/ethereum/solidity/releases/tag/v0.4.24) into the **Tool** folder.
+- Install **Solidity compiler** (version **0.5.10**) binaries for Windows/Linux/OSX from [here](https://github.com/ethereum/solidity/releases/tag/v0.5.10) into the **Tool** folder.
    - (Windows) Download `solc.exe`
    - (Linux) Download the executable `solc-static-linux` use command `chmod +x solc-static-linux` to grant execution permission.
    - (OSX) Download the executable `solc-mac`. use command `chmod +x solc-mac` to grant execution permission (if necessary)
@@ -16,7 +16,8 @@ Make sure that Corral and Corral\Boogie folders are populated. Let us denote %CO
 corral\boogie\binaries\ folders. 
    - (Windows) Follow instructions for [building Corral on Windows](https://github.com/boogie-org/corral#building-and-running-corral-on-windows) and [building Boogie on Windows](https://github.com/boogie-org/boogie#windows)
    - (Linux/OSX) Follow the [building Corral on Linux](https://github.com/boogie-org/corral#building-and-running-corral-on-linux-using-mono) and [building Boogie on Linux/OSX](https://github.com/boogie-org/boogie#linuxosx). Note the dependency on [Mono](https://www.mono-project.com). 
-   - At this point, there should be a copy (Windows) or symbolic link (Linux/OSX) of [Z3 theorem prover](https://github.com/Z3Prover/z3) **z3.exe** present in both %CORRAL_DIR% and %BOOGIE_DIR% folders. 
+   - You need to build Boogie separately to generate **Boogie.exe** (not generated as part of the Corral build)
+   - At this point, there should be a copy (Windows) or symbolic link (Linux/OSX) of [Z3 theorem prover](https://github.com/Z3Prover/z3/releases) **z3.exe** present in both %CORRAL_DIR% and %BOOGIE_DIR% folders. 
 
 ### (Optional) 
    - For Windows, we currently use  [ConcurrencyExplorer](https://github.com/LeeSanderson/Chess) in Corral\Tools\ to view traces (for Windows). It is unclear if one can build the sources of *ConcurencyExplorer* for Linux/OSX from [here](https://github.com/LeeSanderson/Chess). If that works, copy the *ConcurrencyExplorer.exe* binary to Corral\Tools\.

--- a/Sources/SolToBoogie/ConstructorCollector.cs
+++ b/Sources/SolToBoogie/ConstructorCollector.cs
@@ -22,7 +22,7 @@ namespace SolToBoogie
             {
                 if (child is FunctionDefinition function)
                 {
-                    if (function.IsConstructor)
+                    if (function.IsConstructorForContract(node.Name))
                     {
                         context.AddConstructorToContract(node, function);
                     }

--- a/Sources/SolToBoogie/HarnessGenerator.cs
+++ b/Sources/SolToBoogie/HarnessGenerator.cs
@@ -234,7 +234,7 @@ namespace SolToBoogie
             List<FunctionDefinition> publicFuncDefs = new List<FunctionDefinition>();
             foreach (FunctionDefinition funcDef in funcDefs)
             {
-                if (funcDef.IsConstructor) continue;
+                if (funcDef.IsConstructorForContract(contract.Name)) continue;
                 if (funcDef.Visibility == EnumVisibility.PUBLIC || funcDef.Visibility == EnumVisibility.EXTERNAL)
                 {
                     if (funcDef.StateMutability == EnumStateMutability.VIEW || funcDef.StateMutability == EnumStateMutability.PURE)

--- a/Sources/SolToBoogie/MapArrayHelper.cs
+++ b/Sources/SolToBoogie/MapArrayHelper.cs
@@ -38,7 +38,7 @@ namespace SolToBoogie
             {
                 return BoogieType.Ref;
             }
-            else if (typeString.Equals("address"))
+            else if (typeString.Equals("address") || typeString.Equals("address payable"))
             {
                 return BoogieType.Ref;
             }

--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -124,7 +124,7 @@ namespace SolToBoogie
             // procedure name
             string procName = node.Name + "_" + currentContract.Name;
 
-            if (node.IsConstructor)
+            if (node.IsConstructorForContract(currentContract.Name))
             {
                 procName += "_NoBaseCtor";
             }
@@ -143,7 +143,7 @@ namespace SolToBoogie
             // attributes
             List<BoogieAttribute> attributes = new List<BoogieAttribute>();
             if ((node.Visibility == EnumVisibility.PUBLIC || node.Visibility == EnumVisibility.EXTERNAL)
-                && !node.IsConstructor)
+                && !node.IsConstructorForContract(currentContract.Name))
             {
                 attributes.Add(new BoogieAttribute("public"));
             }
@@ -212,7 +212,7 @@ namespace SolToBoogie
                 }
 
                 // initialization statements
-                if (node.IsConstructor)
+                if (node.IsConstructorForContract(currentContract.Name))
                 {
                     BoogieStmtList initStmts = GenerateInitializationStmts(currentContract);
                     initStmts.AppendStmtList(procBody);
@@ -226,7 +226,7 @@ namespace SolToBoogie
             }
 
             // generate real constructors
-            if (node.IsConstructor)
+            if (node.IsConstructorForContract(currentContract.Name))
             {
                 GenerateConstructorWithBaseCalls(node, inParams);
             }
@@ -596,7 +596,7 @@ namespace SolToBoogie
         // generate actual constructor procedures that invoke constructors without base in linearized order
         private void GenerateConstructorWithBaseCalls(FunctionDefinition ctor, List<BoogieVariable> inParams)
         {
-            VeriSolAssert(ctor.IsConstructor, $"{ctor.Name} is not a constructor");
+            VeriSolAssert(ctor.IsConstructorForContract(currentContract.Name), $"{ctor.Name} is not a constructor");
 
             ContractDefinition contract = context.GetContractByFunction(ctor);
             string procName = contract.Name + "_" + contract.Name;

--- a/Sources/SolToBoogie/SolidityDesugaring.cs
+++ b/Sources/SolToBoogie/SolidityDesugaring.cs
@@ -41,7 +41,7 @@ namespace SolToBoogie
             Debug.Assert(currentContract != null);
             currentFunction = node;
 
-            if (node.IsConstructor && string.IsNullOrEmpty(node.Name))
+            if (node.IsConstructorForContract(currentContract.Name) && string.IsNullOrEmpty(node.Name))
             {
                 node.Name = currentContract.Name;
             }

--- a/Sources/SolToBoogie/TranslatorContext.cs
+++ b/Sources/SolToBoogie/TranslatorContext.cs
@@ -250,7 +250,7 @@ namespace SolToBoogie
 
         public void AddConstructorToContract(ContractDefinition contract, FunctionDefinition ctor)
         {
-            Debug.Assert(ctor.IsConstructor, $"{ctor.Name} is not a constructor");
+            Debug.Assert(ctor.IsConstructorForContract(contract.Name), $"{ctor.Name} is not a constructor");
             Debug.Assert(!ContractToConstructorMap.ContainsKey(contract), $"Multiple constructors are defined");
             ContractToConstructorMap[contract] = ctor;
         }

--- a/Sources/SolToBoogieTest/RegressionExecutor.cs
+++ b/Sources/SolToBoogieTest/RegressionExecutor.cs
@@ -94,29 +94,29 @@ namespace SolToBoogieTest
                 else if (batchExeResult == BatchExeResult.SolcError)
                 {
                     ++failedCount;
-                    logger.LogError($"Solc failed - {filename}");
+                    logger.LogError($"Failed (Solc failed) - {filename}");
                 }
                 else if (batchExeResult == BatchExeResult.OtherException)
                 {
                     ++failedCount;
-                    logger.LogError($"Other exception - {filename}");
+                    logger.LogError($"Failed (Other exception) - {filename}");
                 }
                 else if (batchExeResult == BatchExeResult.SolToBoogieError)
                 {
                     ++failedCount;
-                    logger.LogError($"VeriSol translation error - {filename}");
+                    logger.LogError($"Failed (VeriSol translation error) - {filename}");
                 }
                 else if (batchExeResult == BatchExeResult.CorralError)
                 {
                     ++failedCount;
-                    logger.LogError($"Corral regression failed - {filename}");
+                    logger.LogError($"Failed (Corral regression failed) - {filename}");
                     logger.LogError($"\t Expected - {expectedCorralOutput}");
                     logger.LogError($"\t Corral detailed Output - {currentCorralOutput}");
                 }
                 else
                 {
                     ++failedCount;
-                    logger.LogError($"Tool error: unexpected failure code");
+                    logger.LogError($"Failed (Tool error: unexpected failure code) - {filename}");
                 }
             }
 

--- a/Sources/SolidityAST/RegressionExecutor.cs
+++ b/Sources/SolidityAST/RegressionExecutor.cs
@@ -53,7 +53,7 @@ namespace SolidityAST
                 else
                 {
                     ++failedCount;
-                    logger.LogError($"Failed - {filename}");
+                    logger.LogInformation($"Failed - {filename}");
                 }
             }
 

--- a/Sources/SolidityAST/SolidityAST.cs
+++ b/Sources/SolidityAST/SolidityAST.cs
@@ -419,6 +419,8 @@ namespace SolidityAST
 
         public bool IsConstructor { get; set; }
 
+        public bool IsConstructorForContract(string contractName) { return IsConstructor || string.IsNullOrEmpty(Name) || Name.Equals(contractName); }
+
         public bool IsDeclaredConst { get; set; }
 
         public List<ModifierInvocation> Modifiers { get; set; }
@@ -463,6 +465,7 @@ namespace SolidityAST
             StringBuilder builder = new StringBuilder();
             if (IsConstructor && string.IsNullOrEmpty(Name))
             {
+                //will be dead code in solc 0.5.x
                 builder.Append("constructor ");
             }
             else

--- a/Test/records.txt
+++ b/Test/records.txt
@@ -7,7 +7,7 @@ Inheritance.sol
 InheritWithConstructorArgs.sol
 TypeCast.sol
 AddressCast.sol
-MappingReference.sol
+#MappingReference.sol #not backwards compat with 0.4.24
 InheritInitializer.sol
 StaticDispatching.sol
 Event.sol
@@ -60,7 +60,7 @@ IntTypes.sol
 LoopFor.sol
 LoopFor2.sol
 ArrayFixedSize.sol
-MappingLowerDimRef.sol
+#MappingLowerDimRef.sol #Not backward compat with 0.4.24
 InternalFunctionCall.sol
 LoopBreak.sol
 MappingNested.sol

--- a/Test/records.txt
+++ b/Test/records.txt
@@ -7,7 +7,8 @@ Inheritance.sol
 InheritWithConstructorArgs.sol
 TypeCast.sol
 AddressCast.sol
-#MappingReference.sol #not backwards compat with 0.4.24
+#not backwards compat with 0.4.24
+MappingReference.sol 
 InheritInitializer.sol
 StaticDispatching.sol
 Event.sol
@@ -60,7 +61,8 @@ IntTypes.sol
 LoopFor.sol
 LoopFor2.sol
 ArrayFixedSize.sol
-#MappingLowerDimRef.sol #Not backward compat with 0.4.24
+#Not backward compat with 0.4.24
+MappingLowerDimRef.sol 
 InternalFunctionCall.sol
 LoopBreak.sol
 MappingNested.sol

--- a/Test/regressions/Arithmetics.sol
+++ b/Test/regressions/Arithmetics.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Arithmetics {
 

--- a/Test/regressions/ArrayAlias.sol
+++ b/Test/regressions/ArrayAlias.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
 

--- a/Test/regressions/ArrayDynamicStorage.sol
+++ b/Test/regressions/ArrayDynamicStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ArrayDynamicStorage {
 

--- a/Test/regressions/ArrayFixedSize.sol
+++ b/Test/regressions/ArrayFixedSize.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ArrayFixedSize {
 
     uint[2] a;
 
-    constructor() {}
+    constructor() public {}
 
     function test() public {
         a[0] = 1;

--- a/Test/regressions/ArrayInitialization.sol
+++ b/Test/regressions/ArrayInitialization.sol
@@ -1,11 +1,11 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ArrayInit {
 
     uint[2] a;
     uint[2] b;
     
-    function ArrayInit() public {
+    constructor() public {
        b[1] = 22;
        a[1] = 33;
        assert (b[1] == 22);

--- a/Test/regressions/ArrayLength.sol
+++ b/Test/regressions/ArrayLength.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ArrayLength {
 

--- a/Test/regressions/ArrayLengthParam.sol
+++ b/Test/regressions/ArrayLengthParam.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ArrayLength {
 

--- a/Test/regressions/ArrayLowerDimCopy.sol
+++ b/Test/regressions/ArrayLowerDimCopy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ArrayLowerDimCopy {
 

--- a/Test/regressions/ArrayLowerDimRef.sol
+++ b/Test/regressions/ArrayLowerDimRef.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ArrayLowerDimRef {
 

--- a/Test/regressions/ArrayNestedFixedSize.sol
+++ b/Test/regressions/ArrayNestedFixedSize.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ArrayNestedFixedSize {
 

--- a/Test/regressions/ArrayParamAlias.sol
+++ b/Test/regressions/ArrayParamAlias.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 // array variables should not alias with array params or local variables
 

--- a/Test/regressions/ArrayParamCopy.sol
+++ b/Test/regressions/ArrayParamCopy.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 // array variable copy breaks
 

--- a/Test/regressions/ArrayParamCopy.sol
+++ b/Test/regressions/ArrayParamCopy.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.4.24 <0.6.0;
 contract ArrayLength {
     uint[12] a;
 
-    constructor (uint[12] d) 
+    constructor (uint[12] memory d) public
     {
         require (d[1] == 5);
         a = d;       

--- a/Test/regressions/AssertFalse.sol
+++ b/Test/regressions/AssertFalse.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract AssertFalse {
 

--- a/Test/regressions/AssertTrue.sol
+++ b/Test/regressions/AssertTrue.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract AssertTrue {
 

--- a/Test/regressions/Branch.sol
+++ b/Test/regressions/Branch.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Branch {
 

--- a/Test/regressions/Bytes.sol
+++ b/Test/regressions/Bytes.sol
@@ -1,11 +1,11 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Bytes {
 
     bytes public data = "0x3333";
     bytes public empty;
 
-    function clearData(){
+    function clearData() public {
         data = "";
     }
 }

--- a/Test/regressions/Const.sol
+++ b/Test/regressions/Const.sol
@@ -1,15 +1,15 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Consts {
 
-    function Consts() public {
+    constructor () public {
         uint a;
         address b;
         address c;
 
         a = 10;
-        b = 0x10;
-        c = 0x12;
+        b = address(0x10);
+        c = address(0x12);
 
         assert(b != c);
     }

--- a/Test/regressions/Constructor.sol
+++ b/Test/regressions/Constructor.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Foo {
 
     uint a;
 
-    function Foo() public {
+    constructor () public {
         a = 1;
     }
 

--- a/Test/regressions/ConstructorChaining.sol
+++ b/Test/regressions/ConstructorChaining.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
     uint x;

--- a/Test/regressions/ConstructorLinearized.sol
+++ b/Test/regressions/ConstructorLinearized.sol
@@ -1,15 +1,15 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
     uint a;
-    function A() public {
+    constructor () public {
         a = 1;
     }
 }
 
 contract B is A {
     uint b;
-    function B() public {
+    constructor () public {
         a = 2;
         b = 2;
     }
@@ -17,14 +17,14 @@ contract B is A {
 
 contract C is A {
     uint c;
-    function C() public {
+    constructor () public {
         a = 3;
         c = 3;
     }
 }
 
 contract D is B, C {
-    function D() public
+    constructor () public
     {
         assert (a == 3);
         assert (b == 2);

--- a/Test/regressions/ConstructorModifier.sol
+++ b/Test/regressions/ConstructorModifier.sol
@@ -1,21 +1,21 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
     uint a;
-    function A(uint _a) public {
+    constructor (uint _a) public {
         a = _a;
     }
 }
 
 contract B {
     uint b;
-    function B(uint _b) public {
+    constructor (uint _b) public {
         b = _b;
     }
 }
 
 contract C is A, B {
-    function C() public A(1) B(2) {
+    constructor () public A(1) B(2) {
         assert (a == 1);
         assert (b == 2);
     }

--- a/Test/regressions/ConstructorSpecifier.sol
+++ b/Test/regressions/ConstructorSpecifier.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
     uint public a;
     
-    function A(uint _a) public {
+    constructor (uint _a) public {
         a = _a;
     }
 }

--- a/Test/regressions/CreateContract.sol
+++ b/Test/regressions/CreateContract.sol
@@ -1,8 +1,8 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract C {
 
-    constructor () {}
+    constructor () public {}
     function foo(uint x) public returns (uint ret) {
         ret = x + 1;
     }
@@ -12,7 +12,7 @@ contract C {
 contract CreateContract {
 
 
-    function CreateContract() {}
+    constructor () public {}
     function testCreateContract() public {
         C c = new C();
         uint r = c.foo(1);

--- a/Test/regressions/DeleteArray.sol
+++ b/Test/regressions/DeleteArray.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.1;
+pragma solidity >=0.4.24 <0.6.0;
 
 
 contract A {

--- a/Test/regressions/DeleteScalar.sol
+++ b/Test/regressions/DeleteScalar.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 
 contract A {

--- a/Test/regressions/DoWhileLoop.sol
+++ b/Test/regressions/DoWhileLoop.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract DoWhileLoop {
 

--- a/Test/regressions/DynDispatch.sol
+++ b/Test/regressions/DynDispatch.sol
@@ -1,20 +1,20 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 // An example inspired by the virtual dispatch bug in PoA.sol and Tests.sol
 
 contract A {
   uint x;
-  function A() {x = 0;}
-  function Foo() returns (uint) {
+  constructor () public {x = 0;}
+  function Foo() public returns (uint) {
       return 33;
   }
-  function Bar() {
+  function Bar() public {
       uint t = Foo(); //should invoke either A or B's Foo, but not C
   }
 }
 
 contract B is A {
-  function B()  public  {
+  constructor ()  public  {
        uint t;
        t = Foo(); // should only invoke from B
        x = t; 
@@ -32,7 +32,7 @@ contract B is A {
 contract C {
    B b;
 
-   function C(address a) 
+   constructor (address a) public
    { 
       uint t;
       address c = a;

--- a/Test/regressions/EmbeddedCalls.sol
+++ b/Test/regressions/EmbeddedCalls.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 contract B {
    function funcB() public pure returns (uint) {
        return 42;

--- a/Test/regressions/EmptyContract.sol
+++ b/Test/regressions/EmptyContract.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract EmptyContract {
 
     uint a;
 
-    function EmptyContract() public {
+    constructor () public {
         a = 1;
     }
 

--- a/Test/regressions/EnumParam.sol
+++ b/Test/regressions/EnumParam.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract EnumParam {
 

--- a/Test/regressions/EnumType.sol
+++ b/Test/regressions/EnumType.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract EnumType {
 

--- a/Test/regressions/Error.sol
+++ b/Test/regressions/Error.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract AssertFalse {
 

--- a/Test/regressions/Event.sol
+++ b/Test/regressions/Event.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract EventTests {
 
@@ -6,7 +6,7 @@ contract EventTests {
     event EventBar(address indexed addr);
 
     function foo(uint _a) public {
-        EventFoo(msg.sender, _a);
+        emit EventFoo(msg.sender, _a);
     }
 
     function bar() public {

--- a/Test/regressions/ExplicitGetters.sol
+++ b/Test/regressions/ExplicitGetters.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 // translation of explicit getter function for public state variables
 

--- a/Test/regressions/ExternalFunctionCall.sol
+++ b/Test/regressions/ExternalFunctionCall.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ExternalFunctionCall {
 

--- a/Test/regressions/FieldAccess.sol
+++ b/Test/regressions/FieldAccess.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract FieldAccess {
 

--- a/Test/regressions/FuncCallInIfCondition.sol
+++ b/Test/regressions/FuncCallInIfCondition.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
 

--- a/Test/regressions/Getter.sol
+++ b/Test/regressions/Getter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
     address public x;

--- a/Test/regressions/Getters.sol
+++ b/Test/regressions/Getters.sol
@@ -1,8 +1,8 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
     uint public x;
-    constructor () {x = 11;}
+    constructor () public {x = 11;}
 }
 
 contract B {

--- a/Test/regressions/IncDec.sol
+++ b/Test/regressions/IncDec.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract IncDec {
 

--- a/Test/regressions/InheritInitializer.sol
+++ b/Test/regressions/InheritInitializer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract BaseContract {
   mapping (uint => uint) A;
@@ -6,7 +6,7 @@ contract BaseContract {
   uint[] C;  
 
 
-  constructor() {
+  constructor() public {
        A[1] = 1; 
        B[0] = 2; //B.length == 2
        C.push(3); 
@@ -20,7 +20,7 @@ contract DerivedContract is BaseContract {
   mapping (uint => uint) E;
 
   //derived class takes an extra parameter
-  constructor(uint x) {
+  constructor(uint x) public {
        assert(B.length == 2);
        assert(C.length == 1);
        assert(D.length == 4);

--- a/Test/regressions/InheritWithConstructorArgs.sol
+++ b/Test/regressions/InheritWithConstructorArgs.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Base {
     uint x;

--- a/Test/regressions/Inheritance.sol
+++ b/Test/regressions/Inheritance.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract BaseContract {
 

--- a/Test/regressions/InheritanceMultiple.sol
+++ b/Test/regressions/InheritanceMultiple.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Base1 {
 

--- a/Test/regressions/InheritanceWithContractArg.sol
+++ b/Test/regressions/InheritanceWithContractArg.sol
@@ -1,17 +1,17 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A{ 
-    function G() {} //until empty contract bug is fixed. 
+    function G() public {} //until empty contract bug is fixed. 
 }
 
 contract BaseContract {
     uint x;
-    function Foo (A a) { }
+    function Foo (A a) public { }
 }
 
 contract DerivedContract is BaseContract {
 
     uint b;
-    function Foo(A a) { b = 1;}
-    function Bar(A a) {this.Foo(a);}
+    function Foo(A a) public { b = 1;}
+    function Bar(A a) public {this.Foo(a);}
 }

--- a/Test/regressions/InitOutsideCtors.sol
+++ b/Test/regressions/InitOutsideCtors.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
     uint a=1;

--- a/Test/regressions/InputParameters.sol
+++ b/Test/regressions/InputParameters.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract InputParameters {
 

--- a/Test/regressions/IntTypes.sol
+++ b/Test/regressions/IntTypes.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract IntTypes {
 

--- a/Test/regressions/InternalFunctionCall.sol
+++ b/Test/regressions/InternalFunctionCall.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract InternalFunctionCall {
 

--- a/Test/regressions/InternalRecursiveFunctionCall.sol
+++ b/Test/regressions/InternalRecursiveFunctionCall.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract InternalRecursiveFunctionCall {
 

--- a/Test/regressions/Keccak.sol
+++ b/Test/regressions/Keccak.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
 

--- a/Test/regressions/Library.sol
+++ b/Test/regressions/Library.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 //simple library with no internal state
 

--- a/Test/regressions/LibraryStruct.sol
+++ b/Test/regressions/LibraryStruct.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 //simple library with no internal state
 
@@ -19,7 +19,7 @@ contract C {
         assert(aa.x == 22);
     }
    
-    function bar(Lib.A xx) private {
+    function bar(Lib.A memory xx) private {
         xx.x = 22;
     }
 

--- a/Test/regressions/Logical.sol
+++ b/Test/regressions/Logical.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Logical {
 

--- a/Test/regressions/LoopBreak.sol
+++ b/Test/regressions/LoopBreak.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract LoopBreak {
 

--- a/Test/regressions/LoopContinue.sol
+++ b/Test/regressions/LoopContinue.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract LoopContinue {
 

--- a/Test/regressions/LoopDoWhile.sol
+++ b/Test/regressions/LoopDoWhile.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract LoopDoWhile {
 

--- a/Test/regressions/LoopFor.sol
+++ b/Test/regressions/LoopFor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract LoopFor {
 

--- a/Test/regressions/LoopFor2.sol
+++ b/Test/regressions/LoopFor2.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 contract LoopFor2 {
     uint[100] b;
     uint[100] c;
 
-    function LoopFor2() public {
+    constructor () public {
       b[0] = c[0];
     }
     function testUnboundedForLoop(uint n) public {

--- a/Test/regressions/LoopNestedFor.sol
+++ b/Test/regressions/LoopNestedFor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract LoopNestedFor {
 

--- a/Test/regressions/LoopNestedWhile.sol
+++ b/Test/regressions/LoopNestedWhile.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract LoopNestedWhile {
 

--- a/Test/regressions/LoopWhile.sol
+++ b/Test/regressions/LoopWhile.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract LoopWhile {
 

--- a/Test/regressions/Mapping.sol
+++ b/Test/regressions/Mapping.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Mapping {
 

--- a/Test/regressions/MappingInitialize.sol
+++ b/Test/regressions/MappingInitialize.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 
 contract A {
@@ -13,12 +13,12 @@ contract Mapping {
     mapping (string => A) lll;
     mapping (string => address) llll;
 
-    function Mapping() {
+    constructor () public {
         assert (m[10] == 0);
         assert (!n[4]);
         assert (l["a"] == 0);
         assert (!ll["a"]);
-        assert (lll["a"] == address(0x0));
+        assert (address(lll["a"]) == address(0x0));
         assert (llll["a"] == address(0x0));
     }
     function test() public {

--- a/Test/regressions/MappingLowerDimRef.sol
+++ b/Test/regressions/MappingLowerDimRef.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract MappingLowerDimRef {
 
@@ -7,7 +7,7 @@ contract MappingLowerDimRef {
     function test() public {
         x[10][20] = 100;
         x[10][21] = 200;
-        mapping (uint => uint) y = x[10];
+        mapping (uint => uint) storage y = x[10];
         y[20] = 150;
         assert (y[20] == 150);
         assert (y[21] == 200);

--- a/Test/regressions/MappingLowerDimRef.sol
+++ b/Test/regressions/MappingLowerDimRef.sol
@@ -1,4 +1,7 @@
-pragma solidity >=0.4.24 <0.6.0;
+pragma solidity >=0.5.0 <0.6.0;
+// this example does not work wiht 0.4.24 as storage
+// TypeError: Storage location can only be given for array or struct types.
+//        mapping (uint => uint) storage y = x[10]; 
 
 contract MappingLowerDimRef {
 

--- a/Test/regressions/MappingNested.sol
+++ b/Test/regressions/MappingNested.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract MappingNested {
 
@@ -7,7 +7,7 @@ contract MappingNested {
     uint[] p;
   
 
-    constructor() {
+    constructor() public {
         m[10][20] = 11;
         m[20][10] = 21;
         assert (m[10][20] == 11);

--- a/Test/regressions/MappingReference.sol
+++ b/Test/regressions/MappingReference.sol
@@ -1,11 +1,11 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract MappingReference {
 
     mapping (uint => uint) m;
 
     function test() public {
-        mapping (uint => uint) mm = m;
+        mapping (uint => uint) storage mm = m;
         m[10] = 11;
         m[20] = 21;
         mm[10] = 20;

--- a/Test/regressions/MappingReference.sol
+++ b/Test/regressions/MappingReference.sol
@@ -1,4 +1,8 @@
-pragma solidity >=0.4.24 <0.6.0;
+pragma solidity >=0.5.0 <0.6.0;
+// this example does not work wiht 0.4.24 as storage
+// TypeError: Storage location can only be given for array or struct types.
+//        mapping (uint => uint) storage y = x[10]; 
+
 
 contract MappingReference {
 

--- a/Test/regressions/MappingToStruct.sol
+++ b/Test/regressions/MappingToStruct.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract MappingToStruct {
 

--- a/Test/regressions/MethodDecl.sol
+++ b/Test/regressions/MethodDecl.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract MethodDecl {
 
     function test1() public returns (uint);
     
-    function MethodDecl() public {
+    constructor () public {
         uint a;
         a = test1();
     }

--- a/Test/regressions/MethodInConditional.sol
+++ b/Test/regressions/MethodInConditional.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
       uint x;

--- a/Test/regressions/Modifier.sol
+++ b/Test/regressions/Modifier.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Modifier {
 

--- a/Test/regressions/ModifierPost.sol
+++ b/Test/regressions/ModifierPost.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ModifierPost {
 

--- a/Test/regressions/ModifierReturn.sol
+++ b/Test/regressions/ModifierReturn.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ModifierReturn {
 

--- a/Test/regressions/ModifierWithArgs.sol
+++ b/Test/regressions/ModifierWithArgs.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
 

--- a/Test/regressions/ModifierWithInvocations.sol
+++ b/Test/regressions/ModifierWithInvocations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ModifierFunc {
  

--- a/Test/regressions/NestedArray.sol
+++ b/Test/regressions/NestedArray.sol
@@ -1,7 +1,7 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract B{
-   function foo() returns (uint) {return 33;}
+   function foo() public returns (uint) {return 33;}
 }
 
 contract A {

--- a/Test/regressions/NestedFunctionCall.sol
+++ b/Test/regressions/NestedFunctionCall.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
 
@@ -12,7 +12,7 @@ contract NestedFunction {
     A a;
     uint count = 0;
 
-    function NestedFunction() {
+    constructor () public {
     } 
 
     function foo(uint x) internal returns (uint ret) {

--- a/Test/regressions/NoConstructor.sol
+++ b/Test/regressions/NoConstructor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 interface NoConstructor {
     function activate() external;

--- a/Test/regressions/OutputParameters.sol
+++ b/Test/regressions/OutputParameters.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract OutputParameters {
 

--- a/Test/regressions/Require.sol
+++ b/Test/regressions/Require.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Require {
 

--- a/Test/regressions/ReturnMult.sol
+++ b/Test/regressions/ReturnMult.sol
@@ -1,15 +1,15 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ReturnMult {
 
     mapping (uint => uint) m;
     mapping (uint => bool) n;
 
-    function ReturnMult() public {}
+    constructor () public {}
 
     function A() public returns (address)
     {
-        return 0x0;
+        return address(0x0);
     }
 
     function B() public returns (int)

--- a/Test/regressions/ReturnNamedParam.sol
+++ b/Test/regressions/ReturnNamedParam.sol
@@ -1,8 +1,8 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract ReturnNamedParam {
 
-    function ReturnNamedParam() public {}
+    constructor () public {}
 
     function foo() public returns (uint r) {
         return 1;

--- a/Test/regressions/Revert.sol
+++ b/Test/regressions/Revert.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Revert {
 

--- a/Test/regressions/StateVarCall.sol
+++ b/Test/regressions/StateVarCall.sol
@@ -1,9 +1,9 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
     uint public y;
     function helper() private view returns (uint) {return 1;}
-    constructor(A a) {
+    constructor(A a) public {
           uint z;
           y = helper(); //this should be broken up into a temporary
           assert (y == 1);

--- a/Test/regressions/StateVarInit.sol
+++ b/Test/regressions/StateVarInit.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
       uint x;
@@ -7,10 +7,10 @@ contract A {
       address z;
       bool w;
 
-      constructor() {
+      constructor() public {
           assert(x == 0);
           assert(x128 == 0);
-          assert(z == 0x0);
+          assert(z == address(0x0));
           assert(!w);
 
           string memory yval = "";

--- a/Test/regressions/StaticDispatching.sol
+++ b/Test/regressions/StaticDispatching.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract B {
     function foo() public returns(uint) {

--- a/Test/regressions/StringMapping.sol
+++ b/Test/regressions/StringMapping.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Mapping {
 
     mapping (string => uint) m;
 
-    constructor(string s) public {        
+    constructor(string memory s) public {        
         m[s] = 21;    // string memory
         assert (m[s] == 21);
 

--- a/Test/regressions/StringMappingNoConstructor.sol
+++ b/Test/regressions/StringMappingNoConstructor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Mapping {
 

--- a/Test/regressions/StructArray.sol
+++ b/Test/regressions/StructArray.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 // struct arrays and storage
 

--- a/Test/regressions/StructMemory.sol
+++ b/Test/regressions/StructMemory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 //Simplest struct with an array 
 //this version does not use any temporaries

--- a/Test/regressions/StructNested.sol
+++ b/Test/regressions/StructNested.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract StructNested {
 

--- a/Test/regressions/StructNestedConstructor.sol
+++ b/Test/regressions/StructNestedConstructor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 //nested struct constructors
 

--- a/Test/regressions/StructOfDynamicArray.sol
+++ b/Test/regressions/StructOfDynamicArray.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract StructOfDynamicArray {
 

--- a/Test/regressions/StructOfFixedSizeArray.sol
+++ b/Test/regressions/StructOfFixedSizeArray.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract StructOfFixedSizeArray {
 

--- a/Test/regressions/StructOfMapping.sol
+++ b/Test/regressions/StructOfMapping.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract StructOfMapping {
 

--- a/Test/regressions/StructTutorial.sol
+++ b/Test/regressions/StructTutorial.sol
@@ -1,7 +1,7 @@
 // Example from solidity tutorial
 // https://solidity.readthedocs.io/en/v0.4.24/types.html
 
-pragma solidity ^0.4.11;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract CrowdFunding {
     // Defines a new type with two fields.

--- a/Test/regressions/StructType.sol
+++ b/Test/regressions/StructType.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 //Simplest struct with an array 
 //no nested a[i] expressions

--- a/Test/regressions/StructTypeNoTemporaries.sol
+++ b/Test/regressions/StructTypeNoTemporaries.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 //Simplest struct with an array 
 //this version does not use any temporaries

--- a/Test/regressions/This.sol
+++ b/Test/regressions/This.sol
@@ -1,15 +1,15 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 // An example inspired by the virtual dispatch bug in PoA.sol and Tests.sol
 
 contract A {
   uint x;
   
-  function A() { 
+  constructor () public { 
        // this.x = 0; //Solidity does not support this
        this.Foo();
        assert (x == 1);
   }
-  function Foo() {x = 1;}
+  function Foo() public {x = 1;}
 
 }

--- a/Test/regressions/Throw.sol
+++ b/Test/regressions/Throw.sol
@@ -1,11 +1,11 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract Throw {
 
     function testThrow(uint a) public {
         // raw throw is deprecated since version 0.4.13
         // but still common in legacy smart contracts
-        if (a < 10) throw;
+        if (a < 10) revert();
         assert (a >= 10);
     }
 

--- a/Test/regressions/TypeCast.sol
+++ b/Test/regressions/TypeCast.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
     function foo() public returns (uint) {
@@ -18,10 +18,10 @@ contract B {
         address x = address(0x5); 
         address y = address(a); 
         address z = address(new A());
-        assert (z != 0x0);        
+        assert (z != address(0x0));        
 
         //annoying case that survived
         myaddr = address(new A());
-        assert (myaddr != 0x0);                
+        assert (myaddr != address(0x0));                
     }
 }

--- a/Test/regressions/UsingFor.sol
+++ b/Test/regressions/UsingFor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 library Lib {
 

--- a/Test/regressions/abiEncoded.sol
+++ b/Test/regressions/abiEncoded.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract AbiContract {
     function abiCall(uint256 x, uint256 y) private pure returns(bytes memory)

--- a/Test/regressions/abiLibrary.sol
+++ b/Test/regressions/abiLibrary.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
  library abiSample {
     function useAbi2(uint256 a, uint256 b) public pure returns(bytes32) {
          bytes32 h = keccak256(abi.encodePacked(a, b));

--- a/Test/regressions/tuples.sol
+++ b/Test/regressions/tuples.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity >=0.4.24 <0.6.0;
 
 contract A {
    function testTuple() public pure{
@@ -30,6 +30,6 @@ contract A {
    function returnTupleByName() private pure returns (uint a, uint b){
       a = 5;
       b = 55;
-      return; 
+      return (a,b); 
    }
 }

--- a/Test/scripts/ReplacePragma.pl
+++ b/Test/scripts/ReplacePragma.pl
@@ -1,5 +1,6 @@
-# In the directory $ARG[0], finds .sol files and replaces 
+# In the directory $ARG[0], finds .sol files and fixes 
 # "pragma solidity" lines for compiler version 0.5.10
+
 use File::Find; 
 
 sub wanted 

--- a/Test/scripts/ReplacePragma.pl
+++ b/Test/scripts/ReplacePragma.pl
@@ -1,0 +1,51 @@
+# In the directory $ARG[0], finds .sol files and replaces 
+# "pragma solidity" lines for compiler version 0.5.10
+use File::Find; 
+
+sub wanted 
+{
+    print "next file:\n";
+	print $_;
+	print "\n";
+	@temp = substr($_, length($_)-4, 4);
+	#print @temp;
+	#print "\n";
+    if (substr($_, length($_)-4, 4) eq ".sol")
+    {
+		print "found .sol file:\n";
+		print $_;
+		print "\n";
+		@fileName = $_;
+		#print "before open\n";
+        open(IN, $_) or die "Can't open .sol";
+		#print "after open\n";
+        open(OUT,">","temp.out") or die "Can't open temp.out"; 
+		#print "after 2nd open\n";
+    while (<IN>)
+    {
+       @lines = split(" ");
+	   #print "lines[0] is: ";
+       #print @lines[0];
+	   #print "\n";
+	   
+	   if ($lines[0] eq "pragma" && $lines[1] eq "solidity")
+       {
+	      print "found pragma\n";
+          print OUT "pragma solidity >=0.4.24 <0.6.0;\n";
+       }
+       else
+       {
+		  #print "else\n";
+          print OUT $_; 
+       }
+    }
+	#print "after changes are done\n";
+    close IN;
+    close OUT;
+	system("move temp.out @fileName");
+   }    
+
+}
+
+
+find(\&wanted,$ARGV[0]); 


### PR DESCRIPTION
Addressing issue #19 

1. Updrade solc to 0.5.10, and rewrite examples
3. All tests (except 2) should work with >=0.4.24<0.6.0
4. Updated INSTALL.md 