### PR TITLE
Add new AbiEncodePacket for Ref types and basic support for bytes calldata 

### DIFF
--- a/Sources/SolToBoogie/MapArrayHelper.cs
+++ b/Sources/SolToBoogie/MapArrayHelper.cs
@@ -92,6 +92,10 @@ namespace SolToBoogie
                 Match match = arrayRegex.Match(typeString);
                 return BoogieType.Int;
             }
+            else if(typeString=="bytes calldata")
+            {
+                return BoogieType.Ref;
+            }
             else
             {
                 throw new SystemException($"Unknown type string during InferKeyTypeFromTypeString: {typeString}");
@@ -109,6 +113,10 @@ namespace SolToBoogie
             {
                 Match match = arrayRegex.Match(typeString);
                 return InferExprTypeFromTypeString(match.Groups[1].Value);
+            }
+            else if (typeString == "bytes calldata")
+            {
+                return BoogieType.Ref;
             }
             else
             {

--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -1715,6 +1715,9 @@ namespace SolToBoogie
             }
             var boogieExprs = arguments.ConvertAll(x => TranslateExpr(x));
             var funcName = $"abiEncodePacked{arguments.Count}";
+            // hack
+            if(arguments[0].TypeDescriptions.TypeString=="address")
+                funcName = funcName + "R";
             var abiEncodeFuncCall = new BoogieFuncCallExpr(funcName, boogieExprs);
             currentStmtList.AddStatement(new BoogieAssignCmd(lhs, abiEncodeFuncCall));
             return;

--- a/Test/regressions/abiEncoded.sol
+++ b/Test/regressions/abiEncoded.sol
@@ -24,4 +24,21 @@ contract AbiContract {
        assert(keccak256(abi.encodePacked(a, b)) == keccak256(abi.encodePacked(a, b))); //not supported yet
     }
 
+    function encodeAddress(address addr, uint b) public 
+    {
+       bytes32 x = keccak256(abi.encodePacked(addr));
+       bytes32 y = keccak256(abi.encodePacked(addr));
+       assert(x = y);
+       assert(keccak256(abi.encodePacked(addr)) == keccak256(abi.encodePacked(addr))); //not supported yet
+    }
+
+    function encodeAddress2(address addr, uint b) public 
+    {
+       bytes32 x = keccak256(abi.encodePacked(addr, b));
+       bytes32 y = keccak256(abi.encodePacked(addr, b));
+       assert(x == y);
+       assert(keccak256(abi.encodePacked(addr, b)) == keccak256(abi.encodePacked(addr, b))); //not supported yet
+    }
+
+
 }


### PR DESCRIPTION
Add new versions of AbiEncodePacket that allow Ref types as parameters. 
Also a accept bytes calldata as typestring