### PR TITLE
Shuvendu flags

### DIFF
--- a/Sources/SolToBoogie/BoogieTranslator.cs
+++ b/Sources/SolToBoogie/BoogieTranslator.cs
@@ -14,11 +14,13 @@ namespace SolToBoogie
     public class BoogieTranslator
     {
             // set of method@contract pairs whose translatin is skipped
-        public BoogieAST Translate(AST solidityAST, HashSet<Tuple<string, string>> ignoredMethods, bool generateInlineAttributesInBpl)
+        public BoogieAST Translate(AST solidityAST, HashSet<Tuple<string, string>> ignoredMethods, TranslatorFlags _translatorFlags = null)
         {
+            bool generateInlineAttributesInBpl = _translatorFlags.GenerateInlineAttributes;
+
             SourceUnitList sourceUnits = solidityAST.GetSourceUnits();
 
-            TranslatorContext context = new TranslatorContext(ignoredMethods, generateInlineAttributesInBpl);
+            TranslatorContext context = new TranslatorContext(ignoredMethods, generateInlineAttributesInBpl, _translatorFlags);
             context.IdToNodeMap = solidityAST.GetIdToNodeMap();
             context.SourceDirectory = solidityAST.SourceDirectory;
 

--- a/Sources/SolToBoogie/BoogieTranslator.cs
+++ b/Sources/SolToBoogie/BoogieTranslator.cs
@@ -78,9 +78,11 @@ namespace SolToBoogie
             sourceUnits.Accept(procTranslator);
 
             // generate harness for each contract
-            HarnessGenerator harnessGenerator = new HarnessGenerator(context, procTranslator.ContractInvariants);
-            harnessGenerator.Generate();
-
+            if (!context.TranslateFlags.NoHarness)
+            {
+                HarnessGenerator harnessGenerator = new HarnessGenerator(context, procTranslator.ContractInvariants);
+                harnessGenerator.Generate();
+            }
             return new BoogieAST(context.Program);
         }
     }

--- a/Sources/SolToBoogie/GhostVarAndAxiomGenerator.cs
+++ b/Sources/SolToBoogie/GhostVarAndAxiomGenerator.cs
@@ -326,6 +326,9 @@ namespace SolToBoogie
 
         private void GenerateAxioms()
         {
+            if (context.TranslateFlags.NoAxiomsFlag)
+                return;
+
             context.Program.AddDeclaration(GenerateConstToRefAxiom());
             context.Program.AddDeclaration(GenerateKeccakAxiom());
             context.Program.AddDeclaration(GenerateAbiEncodePackedAxiomOneArg());

--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -122,7 +122,7 @@ namespace SolToBoogie
             return false;
         }
 
-        private BoogieCallCmd GenerateBoogieCallCmd(TypeDescription type, BoogieExpr value, string name)
+        private BoogieCallCmd InstrumentForPriningData(TypeDescription type, BoogieExpr value, string name)
         {
             if (type.IsDynamicArray() || type.IsStaticArray())
                 return null;
@@ -151,18 +151,6 @@ namespace SolToBoogie
             }
 
             return null;
-        }
-
-        private BoogieCallCmd InvokeGenerateBoogieCallCmd(TypeDescription type, BoogieExpr value, string name)
-        {
-            if (type.IsDynamicArray() || type.IsStaticArray())
-            {
-                return null; 
-            }
-            else
-            {
-                return GenerateBoogieCallCmd(type, value, name);
-            }
         }
 
         public override bool Visit(FunctionDefinition node)
@@ -194,12 +182,12 @@ namespace SolToBoogie
             TypeDescription addrType = new TypeDescription();
             addrType.TypeString = "address";
             //var callCmd = InvokeGenerateBoogieCallCmd(addrType, new BoogieIdentifierExpr(inParams[0].Name), "this");
-            var callCmd = GenerateBoogieCallCmd(addrType, new BoogieIdentifierExpr(inParams[0].Name), "this");
+            var callCmd = InstrumentForPriningData(addrType, new BoogieIdentifierExpr(inParams[0].Name), "this");
             if (callCmd != null)
             {
                 currentStmtList.AddStatement(callCmd);
             }
-            callCmd = GenerateBoogieCallCmd(addrType, new BoogieIdentifierExpr(inParams[1].Name), "msg.sender");
+            callCmd = InstrumentForPriningData(addrType, new BoogieIdentifierExpr(inParams[1].Name), "msg.sender");
             if (callCmd != null)
             {
                 currentStmtList.AddStatement(callCmd);
@@ -212,7 +200,7 @@ namespace SolToBoogie
                 BoogieVariable parVar = inParams[parIndex + 3];
                 string parName = param.Name;
                 var parExpr = new BoogieIdentifierExpr(parVar.Name);
-                callCmd = GenerateBoogieCallCmd(parType, parExpr, parName);
+                callCmd = InstrumentForPriningData(parType, parExpr, parName);
                 if (callCmd != null)
                 {
                     currentStmtList.AddStatement(callCmd);
@@ -1127,7 +1115,7 @@ namespace SolToBoogie
 
             if (lhsType != null && !isTupleAssignment)
             {
-                var callCmd = GenerateBoogieCallCmd(lhsType, lhs[0], node.LeftHandSide.ToString());
+                var callCmd = InstrumentForPriningData(lhsType, lhs[0], node.LeftHandSide.ToString());
                 if (callCmd != null)
                 {
                     currentStmtList.AddStatement(callCmd);

--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -1213,6 +1213,10 @@ namespace SolToBoogie
 
         private void AddAssumeForUints(BoogieExpr boogieExpr, TypeDescription typeDesc)
         {
+            // skip based on a flag
+            if (context.TranslateFlags.NoUnsignedAssumesFlag)
+                return;
+
             // Add positive number assume for uints
             if (typeDesc!=null && typeDesc.IsUint())
             {

--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -124,6 +124,10 @@ namespace SolToBoogie
 
         private BoogieCallCmd InstrumentForPriningData(TypeDescription type, BoogieExpr value, string name)
         {
+            // don't emit the instrumentation 
+            if (context.TranslateFlags.NoDataValuesInfoFlag)
+                return null;
+
             if (type.IsDynamicArray() || type.IsStaticArray())
                 return null;
 
@@ -1375,12 +1379,15 @@ namespace SolToBoogie
                     var oper = unaryOperation.Operator.Equals("++") ? BoogieBinaryOperation.Opcode.ADD : BoogieBinaryOperation.Opcode.SUB;
                     BoogieExpr rhs = new BoogieBinaryOperation(oper, lhs, new BoogieLiteralExpr(1));
                     BoogieAssignCmd assignCmd = new BoogieAssignCmd(lhs, rhs);
-                    currentStmtList.AddStatement(assignCmd); 
+                    currentStmtList.AddStatement(assignCmd);
                     //print the value
-                    var callCmd = new BoogieCallCmd("boogie_si_record_sol2Bpl_int", new List<BoogieExpr>() { lhs }, new List<BoogieIdentifierExpr>());
-                    callCmd.Attributes = new List<BoogieAttribute>();
-                    callCmd.Attributes.Add(new BoogieAttribute("cexpr", $"\"{unaryOperation.SubExpression.ToString()}\""));
-                    currentStmtList.AddStatement(callCmd);
+                    if (!context.TranslateFlags.NoDataValuesInfoFlag)
+                    {
+                        var callCmd = new BoogieCallCmd("boogie_si_record_sol2Bpl_int", new List<BoogieExpr>() { lhs }, new List<BoogieIdentifierExpr>());
+                        callCmd.Attributes = new List<BoogieAttribute>();
+                        callCmd.Attributes.Add(new BoogieAttribute("cexpr", $"\"{unaryOperation.SubExpression.ToString()}\""));
+                        currentStmtList.AddStatement(callCmd);
+                    }
                     AddAssumeForUints(lhs, unaryOperation.TypeDescriptions);
                 }
                 else if (unaryOperation.Operator.Equals("delete"))
@@ -2419,10 +2426,13 @@ namespace SolToBoogie
                         currentStmtList.AddStatement(assignCmd);
                     }
                     //print the value
-                    var callCmd = new BoogieCallCmd("boogie_si_record_sol2Bpl_int", new List<BoogieExpr>() { expr }, new List<BoogieIdentifierExpr>());
-                    callCmd.Attributes = new List<BoogieAttribute>();
-                    callCmd.Attributes.Add(new BoogieAttribute("cexpr", $"\"{node.SubExpression.ToString()}\""));
-                    currentStmtList.AddStatement(callCmd);
+                    if (!context.TranslateFlags.NoDataValuesInfoFlag)
+                    {
+                        var callCmd = new BoogieCallCmd("boogie_si_record_sol2Bpl_int", new List<BoogieExpr>() { expr }, new List<BoogieIdentifierExpr>());
+                        callCmd.Attributes = new List<BoogieAttribute>();
+                        callCmd.Attributes.Add(new BoogieAttribute("cexpr", $"\"{node.SubExpression.ToString()}\""));
+                        currentStmtList.AddStatement(callCmd);
+                    }
                     break;
                 default:
                     op = BoogieUnaryOperation.Opcode.UNKNOWN;

--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -903,16 +903,19 @@ namespace SolToBoogie
             node.Accept(this);
             VeriSolAssert(currentStmtList != null);
 
+            BoogieStmtList annotatedStmtList = new BoogieStmtList();
             // add source file path and line number
-
-            List<BoogieAttribute> attributes = new List<BoogieAttribute>()
+            if (!context.TranslateFlags.NoSourceLineInfoFlag)
             {
+                List<BoogieAttribute> attributes = new List<BoogieAttribute>()
+                {
                 new BoogieAttribute("first"),
                 new BoogieAttribute("sourceFile", "\"" + srcFileLineInfo.Item1 + "\""),
                 new BoogieAttribute("sourceLine", srcFileLineInfo.Item2)
-            };
-            BoogieAssertCmd annotationCmd = new BoogieAssertCmd(new BoogieLiteralExpr(true), attributes);
-            BoogieStmtList annotatedStmtList = BoogieStmtList.MakeSingletonStmtList(annotationCmd);
+                };
+                BoogieAssertCmd annotationCmd = new BoogieAssertCmd(new BoogieLiteralExpr(true), attributes);
+                annotatedStmtList = BoogieStmtList.MakeSingletonStmtList(annotationCmd);
+            }
             annotatedStmtList.AppendStmtList(currentStmtList);
 
             currentStmtList = oldCurrentStmtList; // pop the stack of currentStmtList

--- a/Sources/SolToBoogie/TestMain.cs
+++ b/Sources/SolToBoogie/TestMain.cs
@@ -76,7 +76,9 @@ namespace SolToBoogie
                 try
                 {
                     BoogieTranslator translator = new BoogieTranslator();
-                    BoogieAST boogieAST = translator.Translate(solidityAST, ignoredMethods, genInlineAttributesInBpl);
+                    var translatorFlags = new TranslatorFlags();
+                    translatorFlags.GenerateInlineAttributes = genInlineAttributesInBpl;
+                    BoogieAST boogieAST = translator.Translate(solidityAST, ignoredMethods, translatorFlags);
 
                     using (var outWriter = new StreamWriter(outFile))
                     {

--- a/Sources/SolToBoogie/TranslatorContext.cs
+++ b/Sources/SolToBoogie/TranslatorContext.cs
@@ -74,6 +74,9 @@ namespace SolToBoogie
         // M -> BoogieImplementation(B) for Modifier M {Stmt A; _; Stmt B}
         public Dictionary<string, BoogieImplementation> ModifierToBoogiePostImpl { get; private set;}
 
+        // Options flags
+        public TranslatorFlags TranslateFlags { get; private set; }
+
         // num of fresh identifiers, should be incremented when making new fresh id
         private int freshIdentifierCount = 0;
 
@@ -83,7 +86,7 @@ namespace SolToBoogie
         // do we generate inline attributes (required for unbounded verification)
         private bool genInlineAttrInBpl;
 
-        public TranslatorContext(HashSet<Tuple<string, string>> ignoreMethods, bool _genInlineAttrInBpl)
+        public TranslatorContext(HashSet<Tuple<string, string>> ignoreMethods, bool _genInlineAttrInBpl, TranslatorFlags _translateFlags = null)
         {
             Program = new BoogieProgram();
             ContractDefinitions = new HashSet<ContractDefinition>();
@@ -110,6 +113,7 @@ namespace SolToBoogie
             ModifierToBoogiePostImpl = new Dictionary<string, BoogieImplementation>();
             IgnoreMethods = ignoreMethods;
             genInlineAttrInBpl = _genInlineAttrInBpl;
+            TranslateFlags = _translateFlags;
         }
 
         public bool HasASTNodeId(int id)

--- a/Sources/SolToBoogie/TranslatorFlags.cs
+++ b/Sources/SolToBoogie/TranslatorFlags.cs
@@ -18,11 +18,30 @@ namespace SolToBoogie
             NoHarness = false; 
             GenerateInlineAttributes = true;
         }
+        /// <summary>
+        /// Omit printing sourceFile/sourceLine information
+        /// </summary>
         public bool NoSourceLineInfoFlag { get; set; }
+        /// <summary>
+        /// Omit printing instrumentation to print data values in counterexample trace
+        /// </summary>
         public bool NoDataValuesInfoFlag{ get; set; }
+        /// <summary>
+        /// Do not print axioms (except for allocation)
+        /// </summary>
         public bool NoAxiomsFlag { get; set; }
+        /// <summary>
+        /// Do not emit x >= 0 for unsigned expressions x
+        /// </summary>
         public bool NoUnsignedAssumesFlag { get; set; }
+        /// <summary>
+        /// Omit generating Corral and Boogie harness
+        /// </summary>
         public bool NoHarness { get; set; }
+        /// <summary>
+        /// When true, add {:inline 1} attribute, 
+        /// can be expensive for recursive procedure analysis by Corral
+        /// </summary>
         public bool GenerateInlineAttributes{ get; set; }
     }
 }

--- a/Sources/SolToBoogie/TranslatorFlags.cs
+++ b/Sources/SolToBoogie/TranslatorFlags.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SolToBoogie
+{
+    /// <summary>
+    /// A set of flags to control the translation
+    /// </summary>
+    public class TranslatorFlags
+    {
+        public TranslatorFlags()
+        {
+            NoSourceLineInfoFlag = false;
+            NoDataValuesInfoFlag = false;
+            NoAxiomsFlag = false;
+            NoUnsignedAssumesFlag = false;
+            GenerateInlineAttributes = true;
+        }
+        public bool NoSourceLineInfoFlag { get; set; }
+        public bool NoDataValuesInfoFlag{ get; set; }
+        public bool NoAxiomsFlag { get; set; }
+        public bool NoUnsignedAssumesFlag { get; set; }
+        public bool GenerateInlineAttributes{ get; set; }
+    }
+}

--- a/Sources/SolToBoogie/TranslatorFlags.cs
+++ b/Sources/SolToBoogie/TranslatorFlags.cs
@@ -15,12 +15,14 @@ namespace SolToBoogie
             NoDataValuesInfoFlag = false;
             NoAxiomsFlag = false;
             NoUnsignedAssumesFlag = false;
+            NoHarness = false; 
             GenerateInlineAttributes = true;
         }
         public bool NoSourceLineInfoFlag { get; set; }
         public bool NoDataValuesInfoFlag{ get; set; }
         public bool NoAxiomsFlag { get; set; }
         public bool NoUnsignedAssumesFlag { get; set; }
+        public bool NoHarness { get; set; }
         public bool GenerateInlineAttributes{ get; set; }
     }
 }

--- a/Sources/SolToBoogieTest/RegressionExecutor.cs
+++ b/Sources/SolToBoogieTest/RegressionExecutor.cs
@@ -147,7 +147,9 @@ namespace SolToBoogieTest
             try
             {
                 BoogieTranslator translator = new BoogieTranslator();
-                BoogieAST boogieAST = translator.Translate(solidityAST, new HashSet<Tuple<string, string>>(), false);
+                var translatorFlags = new TranslatorFlags();
+                translatorFlags.GenerateInlineAttributes = false;
+                BoogieAST boogieAST = translator.Translate(solidityAST, new HashSet<Tuple<string, string>>(), translatorFlags);
 
                 // dump the Boogie program to a file
                 using (var outWriter = new StreamWriter(outFile))

--- a/Sources/VeriSol/Program.cs
+++ b/Sources/VeriSol/Program.cs
@@ -95,9 +95,9 @@ namespace VeriSolRunner
         private static void ParseCommandLineArgs(string[] args, out string solidityFile, out string entryPointContractName, out bool tryProofFlag, out bool tryRefutation, out int recursionBound, out string solcName, out ILogger logger, out HashSet<Tuple<string, string>> ignoredMethods, ref TranslatorFlags translatorFlags)
         {
             solidityFile = args[0];
-            Debug.Assert(solidityFile.Contains("/"), $"Illegal solidity file name {solidityFile}");
+            Debug.Assert(!solidityFile.Contains("/"), $"Illegal solidity file name {solidityFile}");
             entryPointContractName = args[1];
-            Debug.Assert(entryPointContractName.Contains("/"), $"Illegal contract name {entryPointContractName}");
+            Debug.Assert(!entryPointContractName.Contains("/"), $"Illegal contract name {entryPointContractName}");
 
             tryProofFlag = args.Any(x => x.Equals("/tryProof"));
             tryRefutation = false;
@@ -138,19 +138,19 @@ namespace VeriSolRunner
             {
                 Debugger.Launch();
             }
-            if (args.Any(x => x.Equals("/OmitSourceLineInfo")))
+            if (args.Any(x => x.Equals("/omitSourceLineInfo")))
             {
                 translatorFlags.NoSourceLineInfoFlag = true;
             }
-            if (args.Any(x => x.Equals("/OmitDataValuesInTrace")))
+            if (args.Any(x => x.Equals("/omitDataValuesInTrace")))
             {
                 translatorFlags.NoDataValuesInfoFlag = true;
             }
-            if (args.Any(x => x.Equals("/OmitUnsignedSemantics")))
+            if (args.Any(x => x.Equals("/omitUnsignedSemantics")))
             {
                 translatorFlags.NoUnsignedAssumesFlag = true;
             }
-            if (args.Any(x => x.Equals("/OmitAxioms")))
+            if (args.Any(x => x.Equals("/omitAxioms")))
             {
                 translatorFlags.NoAxiomsFlag = true;
             }

--- a/Sources/VeriSol/Program.cs
+++ b/Sources/VeriSol/Program.cs
@@ -154,6 +154,26 @@ namespace VeriSolRunner
             {
                 translatorFlags.NoAxiomsFlag = true;
             }
+            if (args.Any(x => x.Equals("/omitHarness")))
+            {
+                translatorFlags.NoHarness = true;
+            }
+
+            // don't perform verification for some of these omitFlags
+            if (tryProofFlag || tryRefutation)
+            {
+                Debug.Assert(!translatorFlags.NoHarness &&
+                    !translatorFlags.NoAxiomsFlag &&
+                    !translatorFlags.NoUnsignedAssumesFlag &&
+                    !translatorFlags.NoDataValuesInfoFlag &&
+                    !translatorFlags.NoSourceLineInfoFlag,
+                    "Cannot perform verification when any of " +
+                    "/omitSourceLineInfo, " +
+                    "/omitDataValuesInTrace, " +
+                    "/omitAxioms, " +
+                    "/omitHarness, " +
+                    "/omitUnsignedSemantics are specified");
+            }
         }
 
         private static void ShowUsage()

--- a/Sources/VeriSol/Program.cs
+++ b/Sources/VeriSol/Program.cs
@@ -138,7 +138,22 @@ namespace VeriSolRunner
             {
                 Debugger.Launch();
             }
-
+            if (args.Any(x => x.Equals("/OmitSourceLineInfo")))
+            {
+                translatorFlags.NoSourceLineInfoFlag = true;
+            }
+            if (args.Any(x => x.Equals("/OmitDataValuesInTrace")))
+            {
+                translatorFlags.NoDataValuesInfoFlag = true;
+            }
+            if (args.Any(x => x.Equals("/OmitUnsignedSemantics")))
+            {
+                translatorFlags.NoUnsignedAssumesFlag = true;
+            }
+            if (args.Any(x => x.Equals("/OmitAxioms")))
+            {
+                translatorFlags.NoAxiomsFlag = true;
+            }
         }
 
         private static void ShowUsage()

--- a/Sources/VeriSol/VeriSolExecuter.cs
+++ b/Sources/VeriSol/VeriSolExecuter.cs
@@ -26,15 +26,16 @@ namespace VeriSolRunner
         private string SolcName;
         private bool TryProof;
         private bool TryRefutation;
-        private bool GenInlineAttrs;
+        // private bool GenInlineAttrs;
         private ILogger Logger;
         private readonly string outFileName = "__SolToBoogieTest_out.bpl";
         private readonly string corralTraceFileName = "corral_out_trace.txt";
         private readonly int CorralRecursionLimit;
         private readonly int CorralContextBound = 1; // always 1 for solidity
         private HashSet<Tuple<string, string>> ignoreMethods;
+        private TranslatorFlags translatorFlags;
 
-        public VeriSolExecutor(string solidityFilePath, string contractName, string corralPath, string boogiePath, string solcPath, string solcName, int corralRecursionLimit, HashSet<Tuple<string, string>> ignoreMethods, bool tryRefutation, bool tryProofFlag, bool genInlineAttrs, ILogger logger)
+        public VeriSolExecutor(string solidityFilePath, string contractName, string corralPath, string boogiePath, string solcPath, string solcName, int corralRecursionLimit, HashSet<Tuple<string, string>> ignoreMethods, bool tryRefutation, bool tryProofFlag, ILogger logger, TranslatorFlags _translatorFlags = null)
         {
             this.SolidityFilePath = solidityFilePath;
             this.ContractName = contractName;
@@ -49,7 +50,8 @@ namespace VeriSolRunner
             this.Logger = logger;
             this.TryProof = tryProofFlag;
             this.TryRefutation = tryRefutation;
-            this.GenInlineAttrs = genInlineAttrs;
+            //this.GenInlineAttrs = genInlineAttrs;
+            this.translatorFlags = _translatorFlags;
         }
 
         public int Execute()
@@ -213,7 +215,7 @@ namespace VeriSolRunner
             {
                 BoogieTranslator translator = new BoogieTranslator();
                 Console.WriteLine($"\n++ Running SolToBoogie to translate Solidity to Boogie....");
-                BoogieAST boogieAST = translator.Translate(solidityAST, ignoreMethods, GenInlineAttrs);
+                BoogieAST boogieAST = translator.Translate(solidityAST, ignoreMethods, translatorFlags);
 
                 // dump the Boogie program to a file
                 var outFilePath = Path.Combine(SolidityFileDir, outFileName);

--- a/Sources/VeriSolRunner/VeriSolExecuter.cs
+++ b/Sources/VeriSolRunner/VeriSolExecuter.cs
@@ -193,7 +193,9 @@ namespace VeriSolRunner
             {
                 BoogieTranslator translator = new BoogieTranslator();
                 Console.WriteLine($"\n----- Running SolToBoogie....");
-                BoogieAST boogieAST = translator.Translate(solidityAST, ignoreMethods, true);
+                var translatorFlags = new TranslatorFlags();
+                translatorFlags.GenerateInlineAttributes = true;
+                BoogieAST boogieAST = translator.Translate(solidityAST, ignoreMethods, translatorFlags);
 
                 // dump the Boogie program to a file
                 var outFilePath = Path.Combine(SpecFileDir, outFileName);


### PR DESCRIPTION
Adding a few (hidden) flags to guard parts of the translation (not printed as the usage of VeriSol.dll). 

Tested as follows:

`dotnet D:\verisol\Sources\VeriSol\bin\Debug\netcoreapp2.2\VeriSol.dll Mapping.sol Mapping /omitDataValuesInTrace /omitSourceLineInfo /omitUnsignedSemantics /omitAxioms /omitHarness`

The documentation of the flags are only internal in the file SolToBoogie\TranslatorFlags.cs 

