### PR TITLE
print events emitted

### DIFF
--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -1713,6 +1713,11 @@ namespace SolToBoogie
             else if (context.HasEventNameInContract(currentContract, functionName))
             {
                 // generate empty statement list to ignore the event call                
+                List<BoogieAttribute> attributes = new List<BoogieAttribute>()
+                {
+                new BoogieAttribute("EventEmitted", "\"" + functionName + "_" + currentContract.Name + "\""),
+                };
+                currentStmtList.AddStatement(new BoogieAssertCmd(new BoogieLiteralExpr(true), attributes));
             }
             else if (functionName.Equals("call"))
             {


### PR DESCRIPTION
Emit an assert {:EventEmitted "eventFoo_contract"} for "emit eventFoo(…)".

`dotnet C:\verisol\Sources\VeriSol\bin\Debug\netcoreapp2.2\VeriSol.dll Event.sol EventTests`