### PR TITLE
Model Revert Logic

### DIFF
--- a/Sources/SolToBoogie/BoogieTranslator.cs
+++ b/Sources/SolToBoogie/BoogieTranslator.cs
@@ -77,6 +77,12 @@ namespace SolToBoogie
             ProcedureTranslator procTranslator = new ProcedureTranslator(context, generateInlineAttributesInBpl);
             sourceUnits.Accept(procTranslator);
 
+            if (context.TranslateFlags.ModelReverts)
+            {
+                RevertLogicGenerator reverGenerator = new RevertLogicGenerator(context);
+                reverGenerator.Generate();
+            }
+
             // generate harness for each contract
             if (!context.TranslateFlags.NoHarness)
             {

--- a/Sources/SolToBoogie/BoogieTranslator.cs
+++ b/Sources/SolToBoogie/BoogieTranslator.cs
@@ -77,18 +77,19 @@ namespace SolToBoogie
             ProcedureTranslator procTranslator = new ProcedureTranslator(context, generateInlineAttributesInBpl);
             sourceUnits.Accept(procTranslator);
 
-            if (context.TranslateFlags.ModelReverts)
-            {
-                RevertLogicGenerator reverGenerator = new RevertLogicGenerator(context);
-                reverGenerator.Generate();
-            }
-
             // generate harness for each contract
             if (!context.TranslateFlags.NoHarness)
             {
                 HarnessGenerator harnessGenerator = new HarnessGenerator(context, procTranslator.ContractInvariants);
                 harnessGenerator.Generate();
             }
+
+            if (context.TranslateFlags.ModelReverts)
+            {
+                RevertLogicGenerator reverGenerator = new RevertLogicGenerator(context);
+                reverGenerator.Generate();
+            }
+
             return new BoogieAST(context.Program);
         }
     }

--- a/Sources/SolToBoogie/GhostVarAndAxiomGenerator.cs
+++ b/Sources/SolToBoogie/GhostVarAndAxiomGenerator.cs
@@ -175,6 +175,13 @@ namespace SolToBoogie
             BoogieTypedIdent arrayLengthId = new BoogieTypedIdent("Length", type);
             BoogieGlobalVariable arrayLength = new BoogieGlobalVariable(arrayLengthId);
             context.Program.AddDeclaration(arrayLength);
+
+            if (context.TranslateFlags.ModelReverts)
+            {
+                BoogieTypedIdent revertId = new BoogieTypedIdent("revert", BoogieType.Bool);
+                BoogieGlobalVariable revert = new BoogieGlobalVariable(revertId);
+                context.Program.AddDeclaration(revert);
+            }
         }
 
         private void GenerateGlobalImplementations()

--- a/Sources/SolToBoogie/HarnessGenerator.cs
+++ b/Sources/SolToBoogie/HarnessGenerator.cs
@@ -98,6 +98,10 @@ namespace SolToBoogie
             BoogieStmtList harnessBody = new BoogieStmtList();
             harnessBody.AddStatement(GenerateDynamicTypeAssumes(contract));
             GenerateConstructorCall(contract).ForEach(x => harnessBody.AddStatement(x));
+            if (context.TranslateFlags.ModelReverts)
+            {
+                harnessBody.AddStatement(new BoogieAssumeCmd(new BoogieUnaryOperation(BoogieUnaryOperation.Opcode.NOT, new BoogieIdentifierExpr("revert"))));
+            }
             harnessBody.AddStatement(GenerateWhileLoop(contract, houdiniVarMap, localVars));
             BoogieImplementation harnessImpl = new BoogieImplementation(harnessName, inParams, outParams, localVars, harnessBody);
             context.Program.AddDeclaration(harnessImpl);
@@ -362,6 +366,10 @@ namespace SolToBoogie
             BoogieStmtList harnessBody = new BoogieStmtList();
             harnessBody.AddStatement(GenerateDynamicTypeAssumes(contract));
             GenerateConstructorCall(contract).ForEach(x => harnessBody.AddStatement(x));
+            if (context.TranslateFlags.ModelReverts)
+            {
+                harnessBody.AddStatement(new BoogieAssumeCmd(new BoogieUnaryOperation(BoogieUnaryOperation.Opcode.NOT, new BoogieIdentifierExpr("revert"))));
+            }
             harnessBody.AddStatement(GenerateCorralWhileLoop(contract));
             BoogieImplementation harnessImpl = new BoogieImplementation(harnessName, inParams, outParams, localVars, harnessBody);
             context.Program.AddDeclaration(harnessImpl);

--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -1230,31 +1230,8 @@ namespace SolToBoogie
             }
         }
         
-        private void havocReturnVars(BoogieStmtList list)
-        {
-            var retParamCount = 0;
-            List<BoogieIdentifierExpr> varsToHavoc = new List<BoogieIdentifierExpr>();
-            foreach (var retVarDecl in currentFunction.ReturnParameters.Parameters)
-            {
-                string retVarName = String.IsNullOrEmpty(retVarDecl.Name)
-                    ? $"__ret_{retParamCount}_"
-                    : TransUtils.GetCanonicalLocalVariableName(retVarDecl);
-                BoogieIdentifierExpr retVar = new BoogieIdentifierExpr(retVarName);
-                varsToHavoc.Add(retVar);
-            }
-
-            if (varsToHavoc.Count != 0)
-            {
-                Console.Write(varsToHavoc.Count);
-                BoogieHavocCmd havocRets = new BoogieHavocCmd(varsToHavoc);
-                list.AddStatement(havocRets);
-            }
-        }
-        
         private void emitRevertLogic(BoogieStmtList revertLogic)
         {
-            havocReturnVars(revertLogic);
-
             BoogieAssignCmd setRevert = new BoogieAssignCmd(new BoogieIdentifierExpr("revert"), new BoogieLiteralExpr(true));
             revertLogic.AddStatement(setRevert);
 
@@ -1730,7 +1707,7 @@ namespace SolToBoogie
                     
                     emitRevertLogic(revertLogic);
 
-                    BoogieIfCmd requierCheck = new BoogieIfCmd(predicate, revertLogic, null);
+                    BoogieIfCmd requierCheck = new BoogieIfCmd(new BoogieUnaryOperation(BoogieUnaryOperation.Opcode.NOT, predicate), revertLogic, null);
                     
                     currentStmtList.AddStatement(requierCheck);
                 }

--- a/Sources/SolToBoogie/RevertLogicGenerator.cs
+++ b/Sources/SolToBoogie/RevertLogicGenerator.cs
@@ -1,0 +1,403 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace SolToBoogie
+{
+    using BoogieAST;
+    
+    public class RevertLogicGenerator
+    {
+        private TranslatorContext context;
+
+        private HashSet<string> constructorNames;
+
+        private bool mustHaveShadow(string globalName)
+        {
+            return !globalName.Equals("revert");
+        }
+
+        private bool isPublic(BoogieProcedure proc)
+        {
+            if (proc.Attributes != null)
+            {
+                foreach (var attr in proc.Attributes)
+                {
+                    if (attr.Key.Equals("public"))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private BoogieProcedure duplicateProcedure(BoogieProcedure proc, string newNameSuffix, bool dropPublic = false)
+        {
+            BoogieProcedure dup = new BoogieProcedure(proc.Name + "__" + newNameSuffix, 
+                new List<BoogieVariable>(proc.InParams), 
+                new List<BoogieVariable>(proc.OutParams),
+                 proc.Attributes != null ? new List<BoogieAttribute>(proc.Attributes) : null);
+
+            if (dropPublic && dup.Attributes != null)
+                dup.Attributes.RemoveAll(attribute => attribute.Key.Equals("public"));
+
+            return dup;
+        }
+
+        private BoogieImplementation duplicateImplementation(BoogieImplementation impl, string newNameSuffix)
+        {
+            // Duplicate statement list.
+            var dupStmtList = new BoogieStmtList();
+            // Bit hack-y but the setter is private and don't want to touch the BoogieAST file.
+            dupStmtList.BigBlocks.RemoveAt(0);
+            dupStmtList.BigBlocks.AddRange(impl.StructuredStmts.BigBlocks);
+            
+            return new BoogieImplementation(impl.Name + "__" + newNameSuffix,
+                new List<BoogieVariable>(impl.InParams),
+                new List<BoogieVariable>(impl.OutParams),
+                new List<BoogieVariable>(impl.LocalVars),
+                         dupStmtList);
+        }
+
+        private BoogieExpr dupAndReplaceExpr(BoogieExpr expr, Dictionary<string, BoogieGlobalVariable> shadowGlobals,
+                                             Dictionary<string, BoogieImplementation>.KeyCollection procsWiltImpl)
+        {
+            List<BoogieExpr> dupAndReplaceExprList(List<BoogieExpr> exprs)
+            {
+                return exprs.Select(e => dupAndReplaceExpr(e, shadowGlobals, procsWiltImpl)).ToList();
+            }
+
+            if (expr is BoogieIdentifierExpr)
+            {
+                string idName = ((BoogieIdentifierExpr) expr).Name;
+                if (shadowGlobals.ContainsKey(idName))
+                {
+                    return new BoogieIdentifierExpr(shadowGlobals[idName].Name);
+                }
+
+                return expr;
+            }
+            if (expr is BoogieMapSelect)
+            {
+                BoogieMapSelect selectExpr = (BoogieMapSelect) expr;
+                return new BoogieMapSelect(dupAndReplaceExpr(selectExpr.BaseExpr, shadowGlobals, procsWiltImpl),
+                                           dupAndReplaceExprList(selectExpr.Arguments));
+            }
+            if (expr is BoogieMapUpdate)
+            {
+                BoogieMapUpdate updateExpr = (BoogieMapUpdate) expr;
+                return new BoogieMapUpdate(dupAndReplaceExpr(updateExpr.BaseExpr, shadowGlobals, procsWiltImpl), 
+                                           dupAndReplaceExprList(updateExpr.Arguments), 
+                                           dupAndReplaceExpr(updateExpr.Value, shadowGlobals, procsWiltImpl));
+            }
+            if (expr is BoogieUnaryOperation)
+            {
+                BoogieUnaryOperation unaryOperation = (BoogieUnaryOperation) expr;
+                return new BoogieUnaryOperation(unaryOperation.Op, dupAndReplaceExpr(unaryOperation.Expr, shadowGlobals, procsWiltImpl));
+            }
+            if (expr is BoogieBinaryOperation)
+            {
+                BoogieBinaryOperation binOperation = (BoogieBinaryOperation) expr;
+                return new BoogieBinaryOperation(binOperation.Op,dupAndReplaceExpr(binOperation.Lhs, shadowGlobals, procsWiltImpl),
+                                                dupAndReplaceExpr(binOperation.Rhs, shadowGlobals, procsWiltImpl));
+            }
+            if (expr is BoogieITE)
+            {
+                BoogieITE iteExpr = (BoogieITE) expr;
+                return new BoogieITE(dupAndReplaceExpr(iteExpr.Guard, shadowGlobals, procsWiltImpl),
+                                     dupAndReplaceExpr(iteExpr.ThenExpr, shadowGlobals, procsWiltImpl),
+                                     dupAndReplaceExpr(iteExpr.ElseExpr, shadowGlobals, procsWiltImpl));
+            }
+            if (expr is BoogieQuantifiedExpr)
+            {
+                BoogieQuantifiedExpr quantifiedExpr = (BoogieQuantifiedExpr) expr;
+                return  new BoogieQuantifiedExpr(quantifiedExpr.IsForall, quantifiedExpr.QVars, quantifiedExpr.QVarTypes,
+                                                 dupAndReplaceExpr(quantifiedExpr.BodyExpr, shadowGlobals, procsWiltImpl),
+                                                 quantifiedExpr.Trigger);
+            }
+            if (expr is BoogieFuncCallExpr)
+            {
+                BoogieFuncCallExpr callExpr = (BoogieFuncCallExpr) expr;
+
+                string calledFun = callExpr.Function;
+                if (!isConstructor(calledFun) && procsWiltImpl.Contains(calledFun))
+                {
+                    calledFun = calledFun + "__fail";
+
+                    // This is lazy, but I don't want to generalize these methods.
+                    callExpr.Function = callExpr.Function + "__succeess";
+                }
+                
+                return new BoogieFuncCallExpr(calledFun, dupAndReplaceExprList(callExpr.Arguments));
+            }
+            if (expr is BoogieTupleExpr)
+            {
+                BoogieTupleExpr tupleExpr = (BoogieTupleExpr) expr;
+                return  new BoogieTupleExpr(dupAndReplaceExprList(tupleExpr.Arguments));
+            }
+            
+            return expr;
+        }
+
+        private BoogieCmd dupAndReplaceCmd(BoogieCmd cmd, Dictionary<string, BoogieGlobalVariable> shadowGlobals, 
+                                           Dictionary<string, BoogieImplementation>.KeyCollection procsWiltImpl)
+        {
+            List<BoogieExpr> dupAndReplaceExprList(List<BoogieExpr> exprs)
+            {
+                return exprs.Select(e => dupAndReplaceExpr(e, shadowGlobals, procsWiltImpl)).ToList();
+            }
+            
+            BoogieStmtList dupAndReplaceStmList(BoogieStmtList stmtList)
+            {
+                if (stmtList == null)
+                    return null;
+
+                BoogieStmtList newList = new BoogieStmtList();
+                stmtList.BigBlocks[0].SimpleCmds.ForEach(c => newList.AddStatement(dupAndReplaceCmd(c, shadowGlobals, procsWiltImpl)));
+                return newList;
+            }
+            
+            if (cmd is BoogieAssignCmd)
+            {
+                BoogieAssignCmd assignCmd = (BoogieAssignCmd) cmd;
+                return new BoogieAssignCmd(dupAndReplaceExpr(assignCmd.Lhs, shadowGlobals, procsWiltImpl),
+                                           dupAndReplaceExpr(assignCmd.Rhs, shadowGlobals, procsWiltImpl));
+            }
+            if (cmd is BoogieCallCmd)
+            {
+                BoogieCallCmd callCmd = (BoogieCallCmd) cmd;
+
+                string calleeName = callCmd.Callee;
+                if (!isConstructor(calleeName) && procsWiltImpl.Contains(calleeName))
+                {
+                    calleeName = calleeName + "__fail";
+                    
+                    // This is a bit lazy, but I don't want to generalize these methods.
+                    callCmd.Callee = callCmd.Callee + "__success";
+                }
+
+                return new BoogieCallCmd(calleeName, dupAndReplaceExprList(callCmd.Ins), 
+                                         callCmd.Outs.Select(e => (BoogieIdentifierExpr) dupAndReplaceExpr(e, shadowGlobals, procsWiltImpl)).ToList());
+            }
+            if (cmd is BoogieAssertCmd)
+            {
+                BoogieAssertCmd assertCmd = (BoogieAssertCmd) cmd;
+                return new BoogieAssertCmd(dupAndReplaceExpr(assertCmd.Expr, shadowGlobals, procsWiltImpl), assertCmd.Attributes);
+            }
+            if (cmd is BoogieAssumeCmd)
+            {
+                BoogieAssumeCmd assumeCmd = (BoogieAssumeCmd) cmd;
+                return new BoogieAssumeCmd(dupAndReplaceExpr(assumeCmd.Expr, shadowGlobals, procsWiltImpl));
+            }
+            if (cmd is BoogieLoopInvCmd)
+            {
+                BoogieLoopInvCmd loopInvCmd = (BoogieLoopInvCmd) cmd;
+                return new BoogieLoopInvCmd(dupAndReplaceExpr(loopInvCmd.Expr, shadowGlobals, procsWiltImpl));
+            }
+            if (cmd is BoogieReturnExprCmd)
+            {
+                // This one does not seem to be used.
+                BoogieReturnExprCmd returnExprCmd = (BoogieReturnExprCmd) cmd;
+                return new BoogieReturnExprCmd(dupAndReplaceExpr(returnExprCmd.Expr, shadowGlobals, procsWiltImpl));
+            }
+            if (cmd is BoogieHavocCmd)
+            {
+                BoogieHavocCmd havocCmd = (BoogieHavocCmd) cmd;
+                return new BoogieHavocCmd(havocCmd.Vars.Select(id => (BoogieIdentifierExpr) dupAndReplaceExpr(id, shadowGlobals, procsWiltImpl)).ToList());
+            }
+            if (cmd is BoogieIfCmd)
+            {
+                BoogieIfCmd ifCmd = (BoogieIfCmd) cmd;
+                return new BoogieIfCmd(dupAndReplaceExpr(ifCmd.Guard, shadowGlobals, procsWiltImpl),
+                                       dupAndReplaceStmList(ifCmd.ThenBody),
+                                       dupAndReplaceStmList(ifCmd.ElseBody));
+            }
+            if (cmd is BoogieWhileCmd)
+            {
+                BoogieWhileCmd whileCmd = (BoogieWhileCmd) cmd;
+                return new BoogieWhileCmd(dupAndReplaceExpr(whileCmd.Guard, shadowGlobals, procsWiltImpl), 
+                                          dupAndReplaceStmList(whileCmd.Body),
+                                          whileCmd.Invariants.Select(inv => (BoogiePredicateCmd) dupAndReplaceCmd(inv, shadowGlobals, procsWiltImpl)).ToList());
+            }
+            return cmd;
+        }
+
+        private BoogieImplementation createFailImplementation(string name, BoogieImplementation originalImpl, 
+                                                              Dictionary<string, BoogieGlobalVariable> shadowGlobals, 
+                                                              Dictionary<string, BoogieImplementation>.KeyCollection procsWiltImpl)
+        {
+            BoogieStmtList failStmtList = new BoogieStmtList();
+
+            foreach (var cmd in originalImpl.StructuredStmts.BigBlocks[0].SimpleCmds)
+            {
+                failStmtList.AddStatement(dupAndReplaceCmd(cmd, shadowGlobals, procsWiltImpl));
+            }
+
+            return new BoogieImplementation(name, originalImpl.InParams, originalImpl.OutParams, originalImpl.LocalVars, failStmtList);
+        }
+        
+        public RevertLogicGenerator(TranslatorContext context)
+        {
+            this.context = context; 
+            this.constructorNames = context.ContractDefinitions.Select(c => TransUtils.GetCanonicalConstructorName(c)).ToHashSet();
+        }
+
+        bool isConstructor(string funcName)
+        {
+            return constructorNames.Any(funcName.StartsWith);
+        }
+
+        public void Generate()
+        {
+            // Collect Global Variables.
+            HashSet<BoogieGlobalVariable> globals = new HashSet<BoogieGlobalVariable>();
+            foreach (var decl in context.Program.Declarations)
+            {
+                if (decl is BoogieGlobalVariable)
+                {
+                    var g = (BoogieGlobalVariable)decl;
+                    
+                    if (mustHaveShadow(g.Name)) 
+                        globals.Add(g);
+                }
+            }
+            
+            // Generate shadow state.
+            Dictionary<string, BoogieGlobalVariable> shadowGlobals = new Dictionary<string, BoogieGlobalVariable>();
+            foreach (var g in globals)
+            {
+                var varName = g.TypedIdent.Name;
+                BoogieTypedIdent shadowGlobal = new BoogieTypedIdent("__tmp__" + varName, g.TypedIdent.Type);
+                BoogieGlobalVariable shadowGlobalDecl = new BoogieGlobalVariable(shadowGlobal);
+                
+                context.Program.AddDeclaration(shadowGlobalDecl);
+                shadowGlobals.Add(varName, shadowGlobalDecl);
+            }
+            
+            // Duplicate and rename methods.
+            Dictionary<string, BoogieProcedure> proceduresInProgram = new Dictionary<string, BoogieProcedure>();
+           
+            foreach (var decl in context.Program.Declarations)
+            {
+                if (decl is BoogieProcedure)
+                {
+                    var procedure = (BoogieProcedure) decl;
+                    proceduresInProgram.Add(procedure.Name, procedure);
+                }
+            }
+
+            Dictionary<string, BoogieImplementation> proceduresWithImpl = new Dictionary<string, BoogieImplementation>();
+            foreach (var decl in context.Program.Declarations)
+            {
+                if (decl is BoogieImplementation)
+                {
+                    var boogieImpl = ((BoogieImplementation) decl);
+                    if (proceduresInProgram.ContainsKey(boogieImpl.Name))
+                    {
+                        proceduresWithImpl.Add(boogieImpl.Name, boogieImpl);
+                    }
+                }
+                    
+            }
+
+            Dictionary<string, BoogieProcedure> failProcedures = new Dictionary<string, BoogieProcedure>();
+            foreach (var implPair in proceduresWithImpl)
+            {
+                BoogieProcedure proc = proceduresInProgram[implPair.Key];
+
+                if (isPublic(proc))
+                {
+                    // If public maintain original definition as the wrapper.
+                    BoogieProcedure successVersion = duplicateProcedure(proc, "success", true);
+                    BoogieImplementation successImpl = duplicateImplementation(implPair.Value, "success");
+                    
+                    context.Program.AddDeclaration(successVersion);
+                    context.Program.AddDeclaration(successImpl);
+                    
+                    BoogieProcedure failVersion = duplicateProcedure(proc, "fail", true);
+                    
+                    context.Program.AddDeclaration(failVersion);
+                    
+                    // Use original name of the procedure.
+                    failProcedures.Add(implPair.Key, failVersion);
+                }
+                else if (!isConstructor(proc.Name))
+                {
+                    // Otherwise reuse original definition/impl as the "successful" method.
+                    BoogieProcedure failVersion = duplicateProcedure(proc, "fail");
+                    
+                    context.Program.AddDeclaration(failVersion);
+
+                    // Use original name of the procedure.
+                    failProcedures.Add(implPair.Key, failVersion);
+                    
+                    // Reuse original node
+                    proc.Name = proc.Name + "__success";
+                    implPair.Value.Name = implPair.Value.Name + "__success";
+                }
+            }
+            
+            // Create implementations for failing methods.
+
+            foreach (var failProcedurePair in failProcedures)
+            {
+                string procName = failProcedurePair.Key;
+                BoogieProcedure proc = failProcedurePair.Value;
+                
+                context.Program.AddDeclaration(createFailImplementation(proc.Name, proceduresWithImpl[procName], shadowGlobals, proceduresWithImpl.Keys));
+            }
+
+            // A bit hack-y but will hopefully do the trick for now
+            foreach (var nameImplPair in proceduresWithImpl)
+            {
+                var pName = nameImplPair.Key;
+                
+                // This is just to update calls in constructors
+                if (isConstructor(pName))
+                    createFailImplementation(pName, nameImplPair.Value, shadowGlobals, proceduresWithImpl.Keys);
+            }
+            
+            // Create wrappers for public methods.
+
+            foreach (var proc in proceduresInProgram.Values)
+            {
+                if (isPublic(proc))
+                {
+                    BoogieImplementation impl = proceduresWithImpl[proc.Name];
+                    impl.StructuredStmts = new BoogieStmtList();
+                    impl.LocalVars = new List<BoogieVariable>();
+
+                    var exceptionVarName = "__exception";
+                    var revertGlobalName = "revert";
+                    impl.LocalVars.Add(new BoogieLocalVariable(new BoogieTypedIdent(exceptionVarName, BoogieType.Bool)));
+
+                    var stmtList = impl.StructuredStmts;
+                    stmtList.AddStatement(new BoogieHavocCmd(new BoogieIdentifierExpr(exceptionVarName)));
+                    
+                    // Call Successful version.
+                    BoogieStmtList successCallStmtList = new BoogieStmtList();
+                    successCallStmtList.AddStatement(new BoogieCallCmd(impl.Name + "__success", 
+                                                                       impl.InParams.Select(inParam => (BoogieExpr)new BoogieIdentifierExpr(inParam.Name)).ToList(), 
+                                                                       impl.OutParams.Select(outParam => new BoogieIdentifierExpr(outParam.Name)).ToList()));
+                    successCallStmtList.AddStatement(new BoogieAssumeCmd(new BoogieUnaryOperation(BoogieUnaryOperation.Opcode.NOT, new BoogieIdentifierExpr(revertGlobalName))));
+                    
+                    // Call fail version.
+                    BoogieStmtList failCallStmtList = new BoogieStmtList();
+                    // Write global variables to temps
+                    foreach (var shadowGlobalPair in shadowGlobals)
+                    {
+                        string origVarName = shadowGlobalPair.Key;
+                        string shadowName = shadowGlobalPair.Value.Name;
+                        failCallStmtList.AddStatement(new BoogieAssignCmd(new BoogieIdentifierExpr(shadowName), new BoogieIdentifierExpr(origVarName)));
+                    }
+                    failCallStmtList.AddStatement(new BoogieCallCmd(impl.Name + "__fail", 
+                                                 impl.InParams.Select(inParam => (BoogieExpr)new BoogieIdentifierExpr(inParam.Name)).ToList(), 
+                                                impl.OutParams.Select(outParam => new BoogieIdentifierExpr(outParam.Name)).ToList()));
+                    failCallStmtList.AddStatement(new BoogieAssumeCmd(new BoogieIdentifierExpr(revertGlobalName)));
+                    
+                    stmtList.AddStatement(new BoogieIfCmd(new BoogieIdentifierExpr(exceptionVarName), failCallStmtList, successCallStmtList));
+                }
+            }
+        }
+    }
+}

--- a/Sources/SolToBoogie/TranslatorFlags.cs
+++ b/Sources/SolToBoogie/TranslatorFlags.cs
@@ -17,7 +17,7 @@ namespace SolToBoogie
             NoUnsignedAssumesFlag = false;
             NoHarness = false; 
             GenerateInlineAttributes = true;
-            ModelReverts = true;
+            ModelReverts = false;
         }
         /// <summary>
         /// Omit printing sourceFile/sourceLine information

--- a/Sources/SolToBoogie/TranslatorFlags.cs
+++ b/Sources/SolToBoogie/TranslatorFlags.cs
@@ -17,6 +17,7 @@ namespace SolToBoogie
             NoUnsignedAssumesFlag = false;
             NoHarness = false; 
             GenerateInlineAttributes = true;
+            ModelReverts = true;
         }
         /// <summary>
         /// Omit printing sourceFile/sourceLine information
@@ -43,5 +44,9 @@ namespace SolToBoogie
         /// can be expensive for recursive procedure analysis by Corral
         /// </summary>
         public bool GenerateInlineAttributes{ get; set; }
+        /// <summary>
+        /// Model revery logic when an exception happens.
+        /// </summary>
+        public bool ModelReverts { get; set; }
     }
 }

--- a/Sources/VeriSol/Program.cs
+++ b/Sources/VeriSol/Program.cs
@@ -162,6 +162,11 @@ namespace VeriSolRunner
                 translatorFlags.NoHarness = true;
             }
 
+            if (args.Any(x => x.Equals("/modelReverts")))
+            {
+                translatorFlags.ModelReverts = true;
+            }
+
             // don't perform verification for some of these omitFlags
             if (tryProofFlag || tryRefutation)
             {

--- a/Test/regressions/LoopFor2.sol
+++ b/Test/regressions/LoopFor2.sol
@@ -10,7 +10,7 @@ contract LoopFor2 {
       require (n > 0 && n < 100);
       for (uint i = 0; i < n; i += 1) {
         b[i] = i + 1;
-        if (n > 6) { c[i] = b[i] - 1; }
+        if (n > 3) { c[i] = b[i] - 1; }
         else c[i] = b[i];
       }
     }


### PR DESCRIPTION
- Emits explicit revert logic.
- Assumes that all calls propagate assumptions and that there is no reentrancy.
- Emits revert logic only for require statements and explicit revert statements.
- This feature can be enabled with the "ModelReverts" flag (which is false by default).