### PR TITLE
Adding type "bytesK"; new test for "using" bug in a library

### DIFF
--- a/Sources/SolToBoogie/MapArrayHelper.cs
+++ b/Sources/SolToBoogie/MapArrayHelper.cs
@@ -97,7 +97,7 @@ namespace SolToBoogie
             {
                 return BoogieType.Ref;
             }
-            else if (typeString.StartsWith("bytes"))
+            else if (typeString.StartsWith("bytes") && !typeString.Equals("bytes"))
             {
                 return BoogieType.Int;
             }
@@ -123,7 +123,7 @@ namespace SolToBoogie
             {
                 return BoogieType.Ref;
             }
-            else if (typeString.StartsWith("bytes"))
+            else if (typeString.StartsWith("bytes") && !typeString.Equals("bytes"))
             {
                 return BoogieType.Int;
             }

--- a/Sources/SolToBoogie/MapArrayHelper.cs
+++ b/Sources/SolToBoogie/MapArrayHelper.cs
@@ -97,6 +97,10 @@ namespace SolToBoogie
             {
                 return BoogieType.Ref;
             }
+            else if (typeString.StartsWith("bytes"))
+            {
+                return BoogieType.Int;
+            }
             else
             {
                 throw new SystemException($"Unknown type string during InferKeyTypeFromTypeString: {typeString}");
@@ -118,6 +122,10 @@ namespace SolToBoogie
             else if (typeString == "bytes calldata")
             {
                 return BoogieType.Ref;
+            }
+            else if (typeString.StartsWith("bytes"))
+            {
+                return BoogieType.Int;
             }
             else
             {

--- a/Sources/SolToBoogie/TransUtils.cs
+++ b/Sources/SolToBoogie/TransUtils.cs
@@ -360,7 +360,37 @@ namespace SolToBoogie
                     case "address":
                     case "address payable":
                         return BoogieType.Ref;
+                    case "bytes1":
+                    case "bytes2":
+                    case "bytes3":
                     case "bytes4":
+                    case "bytes5":
+                    case "bytes6":
+                    case "bytes7":
+                    case "bytes8":
+                    case "bytes9":
+                    case "bytes10":
+                    case "bytes11":
+                    case "bytes12":
+                    case "bytes13":
+                    case "bytes14":
+                    case "bytes15":
+                    case "bytes16":
+                    case "bytes17":
+                    case "bytes18":
+                    case "bytes19":
+                    case "bytes20":
+                    case "bytes21":
+                    case "bytes22":
+                    case "bytes23":
+                    case "bytes24":
+                    case "bytes25":
+                    case "bytes26":
+                    case "bytes27":
+                    case "bytes28":
+                    case "bytes29":
+                    case "bytes30":
+                    case "bytes31":
                     case "bytes32":
                     case "bytes":
                         return BoogieType.Int;

--- a/Sources/SolToBoogie/TransUtils.cs
+++ b/Sources/SolToBoogie/TransUtils.cs
@@ -360,6 +360,7 @@ namespace SolToBoogie
                     case "address":
                     case "address payable":
                         return BoogieType.Ref;
+                    case "bytes4":
                     case "bytes32":
                     case "bytes":
                         return BoogieType.Int;

--- a/Test/config/BytesTypes.json
+++ b/Test/config/BytesTypes.json
@@ -1,0 +1,6 @@
+{
+    "recursionBound": 8,
+    "k": 1,
+    "main": "CorralEntry_ArrayLength",
+    "expectedResult": "Program has no bugs"
+}

--- a/Test/config/BytesTypes.json
+++ b/Test/config/BytesTypes.json
@@ -1,6 +1,6 @@
 {
     "recursionBound": 8,
     "k": 1,
-    "main": "CorralEntry_ArrayLength",
+    "main": "CorralEntry_Bytes",
     "expectedResult": "Program has no bugs"
 }

--- a/Test/records.txt
+++ b/Test/records.txt
@@ -1,3 +1,4 @@
+BytesTypes.sol
 Const.sol
 UInt.sol
 UInt-1.sol

--- a/Test/regressions/BytesTypes.sol
+++ b/Test/regressions/BytesTypes.sol
@@ -1,0 +1,41 @@
+pragma solidity >=0.4.24 <0.6.0;
+
+// tests bytesXX types
+// Commented asserts repro translator bugs:
+// - when casting bytesK to bytesN, where k < N, no padding with 0s is done (lines 36 and 42)
+// - hex"33" != 0x33  (line 33) 
+contract Bytes {
+    bytes public data = "0x3333";  //dynamically sized array
+    bytes1 public data1 = 0x33;
+	bytes1 public d1 = hex"33";
+	//bytes1 public data1 = "0x3"; 	
+	bytes2 d;
+	bytes2 public data2 = 0x1234;
+	bytes3 public data3 = 0x0;
+	bytes4 public data4;
+	bytes32 public data32 = 0x0;	
+
+	constructor () public {
+		assert (data1 == 0x33);
+		//assert (d1 == data1);              //fails (should pass)
+		d = bytes2(data1);
+		assert (d == data1);
+		//assert (d == 0x3300);            //fails (should pass)
+		//assert(data1[0] == d[0]);        //corral exception
+		
+		//From Solidity doc:
+		bytes2 a = 0x1234;
+	    bytes4 b = bytes4(a);              // b will be 0x12340000
+		//assert (b == 0x12340000);         //fails (should pass)
+        //assert(a[0] == b[0]);				//corral exception
+        //assert(a[1] == b[1]);				//corral exception
+
+		assert (data2 == 0x1234);
+		assert (data3 == 0);
+		data4 = "xyzw";
+		assert (data4 == hex"78797a77");    //passes
+		
+		assert (data32 == 0);
+	}
+ 
+}

--- a/Test/regressions/StringToBytes.sol
+++ b/Test/regressions/StringToBytes.sol
@@ -1,0 +1,20 @@
+pragma solidity >=0.4.24 <0.6.0;
+
+//VeriSol complains about "bytes" arg being called with "string" value
+contract Test {
+ 
+  string z; 
+  constructor () public {
+  }
+  
+  function foo(bytes memory x) public returns (bytes memory y) 
+  {
+     return x;
+  }  
+
+  function test() public returns (bytes memory)
+  {
+	 foo("");
+	 //z = foo("");     //solc detects error
+  }
+}

--- a/Test/regressions/StringToBytes.sol
+++ b/Test/regressions/StringToBytes.sol
@@ -7,14 +7,26 @@ contract Test {
   constructor () public {
   }
   
-  function foo(bytes memory x) public returns (bytes memory y) 
+  function foo(bytes memory x) public 
   {
-     return x;
+	z = "a";
   }  
 
-  function test() public returns (bytes memory)
+  function test() public 
   {
-	 foo("");
+	 //foo("");
+	 //Case #1:
+	 //bytes memory a = new bytes(0);
+	 //foo(a);
+	 
+	 //Case #2:
+	 foo(new bytes(0));      //VeriSol translation error in TranslateNewStatement
+	 
+	 //bytes memory a;
+	 //bytes is same as byte[]
+	 //assert (a.length == 0);
+	 //bytes memory b = delete a;
+	 //foo(a);	 
 	 //z = foo("");     //solc detects error
   }
 }

--- a/Test/regressions/StringToBytes.sol
+++ b/Test/regressions/StringToBytes.sol
@@ -3,13 +3,13 @@ pragma solidity >=0.4.24 <0.6.0;
 //VeriSol complains about "bytes" arg being called with "string" value
 contract Test {
  
-  string z; 
+  //string z; 
   constructor () public {
   }
   
   function foo(bytes memory x) public 
   {
-	z = "a";
+	//z = "a";
   }  
 
   function test() public 
@@ -20,8 +20,13 @@ contract Test {
 	 //foo(a);
 	 
 	 //Case #2:
-	 foo(new bytes(0));      //VeriSol translation error in TranslateNewStatement
+	 //foo(new bytes(0));      //VeriSol translation error in TranslateNewStatement
 	 
+	 //foo(0x);                //solc error
+	 foo(bytes(""));           //works
+	 //foo(0x0);                  //solc error
+	 
+	 //////////////////////////////////////////////////////////////
 	 //bytes memory a;
 	 //bytes is same as byte[]
 	 //assert (a.length == 0);

--- a/Test/regressions/StringToBytes.sol
+++ b/Test/regressions/StringToBytes.sol
@@ -1,37 +1,37 @@
 pragma solidity >=0.4.24 <0.6.0;
 
-//VeriSol complains about "bytes" arg being called with "string" value
+//VeriSol complains about "bytes" arg being called with "string" value (uncomment line 18)
+//VeriSol translation error when "bytes" argument is called with new bytes(0)" (uncomment line 23)
 contract Test {
  
-  //string z; 
+  bytes z; 
+  uint[2] a;
+  uint[2] b;
   constructor () public {
   }
   
-  function foo(bytes memory x) public 
+  function foo(bytes memory x) public returns (bytes memory y)
   {
-	//z = "a";
+	y = x;
   }  
 
   function test() public 
   {
-	 //foo("");
+	 //foo("");           //VeriSol translation error
 	 //Case #1:
 	 //bytes memory a = new bytes(0);
-	 //foo(a);
-	 
+	 //foo(a); 
 	 //Case #2:
 	 //foo(new bytes(0));      //VeriSol translation error in TranslateNewStatement
 	 
 	 //foo(0x);                //solc error
-	 foo(bytes(""));           //works
-	 //foo(0x0);                  //solc error
+	 //foo(0x0);               //solc error
 	 
-	 //////////////////////////////////////////////////////////////
-	 //bytes memory a;
-	 //bytes is same as byte[]
-	 //assert (a.length == 0);
-	 //bytes memory b = delete a;
-	 //foo(a);	 
-	 //z = foo("");     //solc detects error
+	 z = foo(bytes(""));           //compiles
+	 //assert (z == bytes(""));      //solc error
+	 //assert (z == 0x0);             //solc error
+	 assert (z[0] == 0x0);
+	 //assert (z.length == 0);       //solc compiles, but corral crashes:
+									//"Invalid type for argument 0 in map select: int (expected: Ref)"
   }
 }

--- a/Test/regressions/StringToBytes2.sol
+++ b/Test/regressions/StringToBytes2.sol
@@ -1,0 +1,14 @@
+pragma solidity >=0.4.24 <0.6.0;
+
+//VeriSol complains about "bytes" arg type being called with "string" type
+
+contract Test {
+contract b{
+    function safe(bytes memory data) public returns (bytes memory) {
+        return data;
+    }
+    
+    function safeFrom() public  returns (bytes memory)  {
+        return safe("01");
+    }
+}

--- a/Test/regressions/TwoLibraries.sol
+++ b/Test/regressions/TwoLibraries.sol
@@ -2,26 +2,26 @@ pragma solidity >=0.4.24 <0.6.0;
 
 import "SafeMath.sol";
 
-library Counters {
+library Lib {
 	using SafeMath for uint256;
 	
 	struct Counter {
-		uint256 _value;  //default: 0
+		uint256 value;  //default: 0
 	}
 	
 	function decrement(Counter storage counter) internal {
-        counter._value = counter._value.sub(1);
+        counter.value = counter.value.sub(1);
     }
 
 }
-contract NonFungibleBasic {
-    using Counters for Counters.Counter;
+contract A {
+    using Lib for Lib.Counter;
 	
-	mapping (address => Counters.Counter) private _ownedTokensCount;
+	mapping (address => Lib.Counter) private count;
 
-    function _burn(address owner, uint256 tokenId) internal {
+    function foo(address x, uint256 id) internal {
 
-        _ownedTokensCount[owner].decrement();
+        count[x].decrement();
  
     }
 }

--- a/Test/regressions/TwoLibraries.sol
+++ b/Test/regressions/TwoLibraries.sol
@@ -1,0 +1,27 @@
+pragma solidity >=0.4.24 <0.6.0;
+
+import "SafeMath.sol";
+
+library Counters {
+	using SafeMath for uint256;
+	
+	struct Counter {
+		uint256 _value;  //default: 0
+	}
+	
+	function decrement(Counter storage counter) internal {
+        counter._value = counter._value.sub(1);
+    }
+
+}
+contract NonFungibleBasic {
+    using Counters for Counters.Counter;
+	
+	mapping (address => Counters.Counter) private _ownedTokensCount;
+
+    function _burn(address owner, uint256 tokenId) internal {
+
+        _ownedTokensCount[owner].decrement();
+ 
+    }
+}


### PR DESCRIPTION
Test TwoLibraries.sol fails to compile:

> VeriSol translation error: File C:\VeriSol-10-07\verisol\Test\regressions\TwoLibraries.sol, Line 5, Contract Counters, Function decrement:: Unknown type of internal function call: counter._value.sub....

The bug is that IsLibraryFunctionCall method does not account for the case when "using" is located inside a library.