### PR TITLE
Model caught exceptions in revert logic.

### DIFF
--- a/Sources/SolToBoogie/FallbackGenerator.cs
+++ b/Sources/SolToBoogie/FallbackGenerator.cs
@@ -74,6 +74,42 @@ namespace SolToBoogie
             BoogieImplementation unknownFbImpl = new BoogieImplementation(fbUnknownProcName, inParams, outParams, fbLocalVars, fbBody);
             context.Program.AddDeclaration(unknownFbImpl);
 
+            var sendProcName = "send";
+            
+            outParams.Add( new BoogieFormalParam(new BoogieTypedIdent("success", BoogieType.Bool)));
+            BoogieProcedure sendProc = new BoogieProcedure(sendProcName, inParams, outParams, attributes);
+
+            context.Program.AddDeclaration(sendProc);
+
+            BoogieStmtList sendBody = CreateBodyOfSend(inParams, outParams, procName);
+            context.Program.AddDeclaration(new BoogieImplementation(sendProcName, inParams, outParams, localVars, sendBody));
+        }
+
+        private BoogieStmtList CreateBodyOfSend(List<BoogieVariable> inParams, List<BoogieVariable> outParams, string fbProcName)
+        {
+            var fromIdExp = new BoogieIdentifierExpr(inParams[0].Name);
+            var amtIdExp = new BoogieIdentifierExpr(inParams[2].Name);
+            var guard = new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.GE,
+                new BoogieMapSelect(new BoogieIdentifierExpr("Balance"), fromIdExp),
+                amtIdExp);
+
+            // call FallbackDispatch(from, to, amount)
+            var toIdExpr = new BoogieIdentifierExpr(inParams[1].Name);
+            var callStmt = new BoogieCallCmd(
+                fbProcName,
+                new List<BoogieExpr>() { fromIdExp, toIdExpr, amtIdExp},
+                new List<BoogieIdentifierExpr>()
+            );
+
+            var thenBody = new BoogieStmtList();
+            var successIdExp = new BoogieIdentifierExpr(outParams[0].Name);
+            thenBody.AddStatement(callStmt); 
+            thenBody.AddStatement(new BoogieAssignCmd(successIdExp, new BoogieLiteralExpr(true)));
+
+            var elseBody = new BoogieAssignCmd(successIdExp, new BoogieLiteralExpr(false));
+
+            return BoogieStmtList.MakeSingletonStmtList(new BoogieIfCmd(guard, thenBody,
+                BoogieStmtList.MakeSingletonStmtList(elseBody)));
         }
 
         private BoogieStmtList CreateBodyOfUnknownFallback(List<BoogieVariable> fbLocalVars, List<BoogieVariable> inParams)

--- a/Sources/SolToBoogie/FallbackGenerator.cs
+++ b/Sources/SolToBoogie/FallbackGenerator.cs
@@ -76,13 +76,13 @@ namespace SolToBoogie
 
             var sendProcName = "send";
             
-            outParams.Add( new BoogieFormalParam(new BoogieTypedIdent("success", BoogieType.Bool)));
-            BoogieProcedure sendProc = new BoogieProcedure(sendProcName, inParams, outParams, attributes);
+            var sendOutParams = new List<BoogieVariable>(){ new BoogieFormalParam(new BoogieTypedIdent("success", BoogieType.Bool))};
+            BoogieProcedure sendProc = new BoogieProcedure(sendProcName, inParams, sendOutParams, attributes);
 
             context.Program.AddDeclaration(sendProc);
 
-            BoogieStmtList sendBody = CreateBodyOfSend(inParams, outParams, procName);
-            context.Program.AddDeclaration(new BoogieImplementation(sendProcName, inParams, outParams, localVars, sendBody));
+            BoogieStmtList sendBody = CreateBodyOfSend(inParams, sendOutParams, procName);
+            context.Program.AddDeclaration(new BoogieImplementation(sendProcName, inParams, sendOutParams, localVars, sendBody));
         }
 
         private BoogieStmtList CreateBodyOfSend(List<BoogieVariable> inParams, List<BoogieVariable> outParams, string fbProcName)

--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -2414,9 +2414,19 @@ namespace SolToBoogie
                 new List<BoogieIdentifierExpr>() {retVar});
             
             currentStmtList.AddStatement(callStmt);
-            
-            var assumeStmt = new BoogieAssumeCmd(retVar);
-            currentStmtList.AddStatement(assumeStmt);
+
+            if (!context.TranslateFlags.ModelReverts)
+            {
+                var assumeStmt = new BoogieAssumeCmd(retVar);
+                currentStmtList.AddStatement(assumeStmt);
+            }
+            else
+            {
+                var revertLogic = new BoogieStmtList();
+                emitRevertLogic(revertLogic);
+                currentStmtList.AddStatement(new BoogieIfCmd(new BoogieUnaryOperation(BoogieUnaryOperation.Opcode.NOT, retVar), revertLogic, null));
+            }
+
             return;
         }
 

--- a/Sources/SolToBoogie/ProcedureTranslator.cs
+++ b/Sources/SolToBoogie/ProcedureTranslator.cs
@@ -2405,11 +2405,18 @@ namespace SolToBoogie
         private void TranslateTransferCallStmt(FunctionCall node)
         {
             var amountExpr = TranslateExpr(node.Arguments[0]);
+            var memberAccess = node.Expression as MemberAccess;
+            var baseExpr = memberAccess.Expression;
+            var retVar = MkNewLocalVariableWithType(BoogieType.Bool);
 
-            // call FallbackDispatch(from, to, amount)
-            BoogieCallCmd callStmt = MkFallbackDispatchCallCmd(node, amountExpr);
-
+            var callStmt = new BoogieCallCmd("send",
+                new List<BoogieExpr>() {new BoogieIdentifierExpr("this"), TranslateExpr(baseExpr), amountExpr},
+                new List<BoogieIdentifierExpr>() {retVar});
+            
             currentStmtList.AddStatement(callStmt);
+            
+            var assumeStmt = new BoogieAssumeCmd(retVar);
+            currentStmtList.AddStatement(assumeStmt);
             return;
         }
 
@@ -2429,21 +2436,17 @@ namespace SolToBoogie
 
         private void TranslateSendCallStmt(FunctionCall node, BoogieIdentifierExpr returnExpr, BoogieExpr amountExpr)
         {
-            var guard = new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.GE,
-                new BoogieMapSelect(new BoogieIdentifierExpr("Balance"), new BoogieIdentifierExpr("this")),
-                amountExpr);
-
-            // call FallbackDispatch(from, to, amount)
-            var callStmt = MkFallbackDispatchCallCmd(node, amountExpr);
-
-            var thenBody = new BoogieStmtList();
-            thenBody.AddStatement(callStmt); 
-            thenBody.AddStatement(new BoogieAssignCmd(returnExpr, new BoogieLiteralExpr(true)));
-
-            var elseBody = new BoogieAssignCmd(returnExpr, new BoogieLiteralExpr(false));
-
-            currentStmtList.AddStatement(new BoogieIfCmd(guard, thenBody, BoogieStmtList.MakeSingletonStmtList(elseBody)));
-            return;
+            var memberAccess = node.Expression as MemberAccess;
+            var baseExpr = memberAccess.Expression;
+            
+            var ins = new List<BoogieExpr>();
+            ins.Add(new BoogieIdentifierExpr("this"));
+            ins.Add(TranslateExpr(baseExpr));
+            ins.Add(amountExpr);
+         
+            var outs = new List<BoogieIdentifierExpr>();
+            outs.Add(returnExpr);
+            currentStmtList.AddStatement(new BoogieCallCmd("send", ins, outs));
         }
 
         private void TranslateNewStatement(FunctionCall node, BoogieExpr lhs)

--- a/Sources/SolToBoogie/RevertLogicGenerator.cs
+++ b/Sources/SolToBoogie/RevertLogicGenerator.cs
@@ -129,6 +129,11 @@ namespace SolToBoogie
             return expr;
         }
 
+        bool catchesExceptions(string methodName)
+        {
+            return methodName.Equals("send");
+        }
+
         private void generateRevertLogicForCmd(BoogieCmd cmd, BoogieStmtList parent, bool isFail, bool inHarness)
         {
             List<BoogieExpr> dupAndReplaceExprList(List<BoogieExpr> exprs)
@@ -159,13 +164,13 @@ namespace SolToBoogie
                 {
                     if (!inHarness || !isPublic(proceduresInProgram[calleeName]))
                     {
+                        emitCheckRevertLogic = !inHarness && !catchesExceptions(calleeName);
                         calleeName = calleeName + (isFail ? "__fail" : "__success");
-                        emitCheckRevertLogic = !inHarness;
                     }
                 }
 
                 var newIns = callCmd.Ins != null ? dupAndReplaceExprList(callCmd.Ins) : null;
-                var newOuts = callCmd.Outs != null ? callCmd.Outs.Select(e => (BoogieIdentifierExpr) dupAndReplaceExpr(e, isFail, inHarness)).ToList() : null;
+                var newOuts = callCmd.Outs?.Select(e => (BoogieIdentifierExpr) dupAndReplaceExpr(e, isFail, inHarness)).ToList();
                 parent.AddStatement(new BoogieCallCmd(calleeName, newIns, newOuts));
 
                 if (emitCheckRevertLogic)
@@ -348,8 +353,16 @@ namespace SolToBoogie
                 BoogieProcedure proc = failProcedurePair.Value;
 
                 var originalImpl = proceduresWithImpl[originalProcName];
-                context.Program.AddDeclaration(createFailImplementation(proc.Name, originalImpl));
-                context.Program.AddDeclaration(createSuccessImplementation(originalProcName + "__success", originalImpl));
+                if (!originalProcName.Equals("send"))
+                {
+                    context.Program.AddDeclaration(createFailImplementation(proc.Name, originalImpl));
+                    context.Program.AddDeclaration(createSuccessImplementation(originalProcName + "__success", originalImpl));
+                }
+                else
+                {
+                    context.Program.AddDeclaration(CreateSendFail());
+                    context.Program.AddDeclaration(CreateSendSucess());
+                }
 
                 // Remove original implementation for non-public methods
                 if (!isPublic(proceduresInProgram[originalProcName]) && !isConstructor(originalProcName))
@@ -423,6 +436,241 @@ namespace SolToBoogie
                     stmtList.AddStatement(new BoogieIfCmd(new BoogieIdentifierExpr(exceptionVarName), failCallStmtList, successCallStmtList));
                 }
             }
+        }
+
+        private BoogieImplementation CreateSendFail()
+        {
+            // send__fail(from: Ref, to: Ref, amt: uint) returns (success: boolean)
+            // {
+            //    var __exception: bool;
+            //    havoc __exception;
+            //
+            //    if(__exception)
+            //    {
+            //       //save current temps
+            //      if ((__tmp__Balance[from]) >= (amt)) {
+            //           call FallbackDispatch__fail(from, to, amt);
+            //      }
+            //
+            //       success := false;
+            //       assume(__revert);
+            //
+            //       // restore old temps
+            //       revert := false;
+            //    }
+            //    else {
+            //       if ((__tmp__Balance[from]) >= (amt)) {
+            //           call FallbackDispatch__fail(from, to, amt);
+            //           success := true;
+            //       } else {
+            //           success := false;
+            //       }
+            //
+            //       assume(!(__revert));
+            //    }
+            // }
+
+            List<BoogieVariable> inParams = new List<BoogieVariable>()
+            {
+                new BoogieFormalParam(new BoogieTypedIdent("from", BoogieType.Ref)),
+                new BoogieFormalParam(new BoogieTypedIdent("to", BoogieType.Ref)),
+                new BoogieFormalParam(new BoogieTypedIdent("amount", BoogieType.Int))
+            };
+
+            List<BoogieVariable> outParms = new List<BoogieVariable>()
+            {
+                new BoogieFormalParam(new BoogieTypedIdent("success", BoogieType.Bool))
+            };
+
+            List<BoogieVariable> locals = new List<BoogieVariable>()
+            {
+                new BoogieLocalVariable(new BoogieTypedIdent("__exception", BoogieType.Bool))
+            };
+
+            var fromId = new BoogieIdentifierExpr("from");
+            var toId = new BoogieIdentifierExpr("to");
+            var amtId = new BoogieIdentifierExpr("amount");
+
+            var successId = new BoogieIdentifierExpr("success");
+
+            var revertId = new BoogieIdentifierExpr("__revert");
+
+            var exceptionId = new BoogieIdentifierExpr("__exception");
+
+            var body = new BoogieStmtList();
+
+            body.AddStatement(new BoogieHavocCmd(exceptionId));
+
+            var checkTmpBalGuard = new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.GE,
+                new BoogieMapSelect(new BoogieIdentifierExpr(shadowGlobals["Balance"].Name), fromId), 
+                amtId);
+            var callFailDispatch = new BoogieCallCmd("FallbackDispatch__fail", new List<BoogieExpr>() {fromId, toId, amtId}, null);
+
+            var exceptionCase = new BoogieStmtList();
+
+            foreach (var shadowGlobalPair in shadowGlobals)
+            {
+                var shadowName = shadowGlobalPair.Value.Name;
+                var tmpLocalName = "__snap_" + shadowName;
+                locals.Add(new BoogieLocalVariable(new BoogieTypedIdent(tmpLocalName, shadowGlobalPair.Value.TypedIdent.Type)));
+
+                exceptionCase.AddStatement(new BoogieAssignCmd(new BoogieIdentifierExpr(tmpLocalName), new BoogieIdentifierExpr(shadowName)));
+            }
+
+            exceptionCase.AddStatement(new BoogieIfCmd(checkTmpBalGuard, BoogieStmtList.MakeSingletonStmtList(callFailDispatch), null));
+            exceptionCase.AddStatement(new BoogieAssignCmd(successId, new BoogieLiteralExpr(false)));
+            BoogieExpr failAssumePred = revertId;
+            if (context.TranslateFlags.InstrumentGas)
+            {
+                failAssumePred = new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.OR, failAssumePred, new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.LT, new BoogieIdentifierExpr("gas"), new BoogieLiteralExpr(0)));
+            }
+
+            exceptionCase.AddStatement(new BoogieAssumeCmd(failAssumePred));
+
+            foreach (var shadowGlobalPair in shadowGlobals)
+            {
+                var shadowName = shadowGlobalPair.Value.Name;
+                var tmpLocalName = "__snap_" + shadowName;
+
+                exceptionCase.AddStatement(new BoogieAssignCmd(new BoogieIdentifierExpr(shadowName), new BoogieIdentifierExpr(tmpLocalName)));
+            }
+
+            exceptionCase.AddStatement(new BoogieAssignCmd(revertId, new BoogieLiteralExpr(false)));
+
+            var successCase = new BoogieStmtList();
+            var successDispatchCall = new BoogieStmtList();
+
+            successDispatchCall.AddStatement(callFailDispatch);
+            successDispatchCall.AddStatement(new BoogieAssignCmd(successId, new BoogieLiteralExpr(true)));
+
+            successCase.AddStatement(new BoogieIfCmd(checkTmpBalGuard, successDispatchCall, BoogieStmtList.MakeSingletonStmtList(new BoogieAssignCmd(successId, new BoogieLiteralExpr(false)))));
+            BoogieExpr successAssumePred = new BoogieUnaryOperation(BoogieUnaryOperation.Opcode.NOT, revertId);
+
+            if (context.TranslateFlags.InstrumentGas)
+            {
+                successAssumePred = new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.AND, successAssumePred, new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.GE, new BoogieIdentifierExpr("gas"), new BoogieLiteralExpr(0)));
+            }
+
+            successCase.AddStatement(new BoogieAssumeCmd(successAssumePred));
+
+            body.AddStatement(new BoogieIfCmd(exceptionId, exceptionCase, successCase));
+            return new BoogieImplementation("send__fail", inParams, outParms, locals, body);
+        }
+
+        private BoogieImplementation CreateSendSucess()
+        {
+            // send__success(from: Ref, to: Ref, amt: uint) returns (success: boolean)
+            // {
+            //    var __exception: bool;
+            //    havoc __exception;
+            //
+            //    if(__exception)
+            //    {
+            //        //set tmps
+            //        if ((__tmp__Balance[from]) >= (amt)) {
+            //            call FallbackDispatch__fail(from, to, amt);
+            //        }
+            //
+            //        success := false;
+            //        assume(__revert);
+            //
+            //        revert := false;
+            //    }
+            //    else {
+            //        if ((Balance[from]) >= (amt)) {
+            //            call FallbackDispatch__success(from, to, amt);
+            //            success := true;
+            //        } else {
+            //            success := false;
+            //        }
+            //
+            //        assume(!(__revert));
+            //    }
+            // }
+
+            List<BoogieVariable> inParams = new List<BoogieVariable>()
+            {
+                new BoogieFormalParam(new BoogieTypedIdent("from", BoogieType.Ref)),
+                new BoogieFormalParam(new BoogieTypedIdent("to", BoogieType.Ref)),
+                new BoogieFormalParam(new BoogieTypedIdent("amount", BoogieType.Int))
+            };
+
+            List<BoogieVariable> outParms = new List<BoogieVariable>()
+            {
+                new BoogieFormalParam(new BoogieTypedIdent("success", BoogieType.Bool))
+            };
+
+            List<BoogieVariable> locals = new List<BoogieVariable>()
+            {
+                new BoogieLocalVariable(new BoogieTypedIdent("__exception", BoogieType.Bool))
+            };
+
+
+            var fromId = new BoogieIdentifierExpr("from");
+            var toId = new BoogieIdentifierExpr("to");
+            var amtId = new BoogieIdentifierExpr("amount");
+
+            var successId = new BoogieIdentifierExpr("success");
+
+            var revertId = new BoogieIdentifierExpr("__revert");
+
+            var exceptionId = new BoogieIdentifierExpr("__exception");
+
+            BoogieStmtList body = new BoogieStmtList();
+
+            body.AddStatement(new BoogieHavocCmd(exceptionId));
+
+            BoogieStmtList exceptionCase = new BoogieStmtList();
+
+            foreach (var shadowGlobalPair in shadowGlobals)
+            {
+                string origVarName = shadowGlobalPair.Key;
+                string shadowName = shadowGlobalPair.Value.Name;
+                exceptionCase.AddStatement(new BoogieAssignCmd(new BoogieIdentifierExpr(shadowName), new BoogieIdentifierExpr(origVarName)));
+            }
+
+            var checkTmpBalGuard = new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.GE,
+                new BoogieMapSelect(new BoogieIdentifierExpr(shadowGlobals["Balance"].Name), fromId),
+                amtId);
+            var callFailDispatch = new BoogieCallCmd("FallbackDispatch__fail", new List<BoogieExpr>() {fromId, toId, amtId}, null);
+
+            exceptionCase.AddStatement(new BoogieIfCmd(checkTmpBalGuard, BoogieStmtList.MakeSingletonStmtList(callFailDispatch), null));
+
+            exceptionCase.AddStatement(new BoogieAssignCmd(successId, new BoogieLiteralExpr(false)));
+
+            BoogieExpr failAssumePred = revertId;
+            if (context.TranslateFlags.InstrumentGas)
+            {
+                failAssumePred = new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.OR, failAssumePred, new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.LT, new BoogieIdentifierExpr("gas"), new BoogieLiteralExpr(0)));
+            }
+
+            exceptionCase.AddStatement(new BoogieAssumeCmd(failAssumePred));
+            exceptionCase.AddStatement(new BoogieAssignCmd(revertId, new BoogieLiteralExpr(false)));
+
+            var successCase = new BoogieStmtList();
+
+            var checkBalGuard = new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.GE,
+                new BoogieMapSelect(new BoogieIdentifierExpr("Balance"), fromId),
+                amtId);
+
+            var successCaseStmts = new BoogieStmtList();
+            var callSuccessDispatch = new BoogieCallCmd("FallbackDispatch__success", new List<BoogieExpr>(){fromId, toId, amtId}, null);
+            successCaseStmts.AddStatement(callSuccessDispatch);
+            successCaseStmts.AddStatement(new BoogieAssignCmd(successId, new BoogieLiteralExpr(true)));
+
+            successCase.AddStatement(new BoogieIfCmd(checkBalGuard, successCaseStmts, BoogieStmtList.MakeSingletonStmtList(new BoogieAssignCmd(successId, new BoogieLiteralExpr(false)))));
+
+            BoogieExpr successAssumePred = new BoogieUnaryOperation(BoogieUnaryOperation.Opcode.NOT, revertId);
+
+            if (context.TranslateFlags.InstrumentGas)
+            {
+                successAssumePred = new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.AND, successAssumePred, new BoogieBinaryOperation(BoogieBinaryOperation.Opcode.GE, new BoogieIdentifierExpr("gas"), new BoogieLiteralExpr(0)));
+            }
+
+            successCase.AddStatement(new BoogieAssumeCmd(successAssumePred));
+
+            body.AddStatement(new BoogieIfCmd(exceptionId, exceptionCase, successCase));
+            return new BoogieImplementation("send__success", inParams, outParms, locals, body);
         }
     }
 }

--- a/Sources/SolToBoogie/RevertLogicGenerator.cs
+++ b/Sources/SolToBoogie/RevertLogicGenerator.cs
@@ -493,7 +493,7 @@ namespace SolToBoogie
 
             var successId = new BoogieIdentifierExpr("success");
 
-            var revertId = new BoogieIdentifierExpr("__revert");
+            var revertId = new BoogieIdentifierExpr("revert");
 
             var exceptionId = new BoogieIdentifierExpr("__exception");
 
@@ -612,7 +612,7 @@ namespace SolToBoogie
 
             var successId = new BoogieIdentifierExpr("success");
 
-            var revertId = new BoogieIdentifierExpr("__revert");
+            var revertId = new BoogieIdentifierExpr("revert");
 
             var exceptionId = new BoogieIdentifierExpr("__exception");
 


### PR DESCRIPTION
Handling of reverts inside sends. I had to modify the FallbackGenerator a bit to generate a send procedure. I needed that to model reverts for transfer statements. With the previous implementation, transfer statements could "fail" by violating the assumption that the current balance is insufficient. However, this assumption was generated inside the Fallback procedure, which made the handling of reverts a bit messy. Now, I model transfer statements as follows: require(send(from, to, amt));